### PR TITLE
Fix/fix stale read

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/ReplicatorGroup.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/ReplicatorGroup.java
@@ -93,7 +93,7 @@ public interface ReplicatorGroup {
     boolean waitCaughtUp(PeerId peer, long maxMargin, long dueTime, CatchUpClosure done);
 
     /**
-     * Get peer's last rpc send timestamp.
+     * Get peer's last rpc send timestamp (monotonic time in milliseconds).
      *
      * @param peer the peer of replicator
      */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1244,11 +1244,10 @@ public class NodeImpl implements Node, RaftServerService {
             switch (readOnlyOpt) {
                 case ReadOnlySafe:
                     final List<PeerId> peers = this.conf.getConf().getPeers();
-                    final ReadIndexHeartbeatResponseClosure heartbeatDone = new ReadIndexHeartbeatResponseClosure(
-                        closure, respBuilder, quorum, peers.size());
-
                     Requires.requireNonNull(peers, "Peer is null");
                     Requires.requireTrue(!peers.isEmpty(), "Peer is empty");
+                    final ReadIndexHeartbeatResponseClosure heartbeatDone = new ReadIndexHeartbeatResponseClosure(
+                        closure, respBuilder, quorum, peers.size());
                     // Send heartbeat requests to followers
                     for (final PeerId peer : peers) {
                         if (peer.equals(this.serverId)) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1754,7 +1754,7 @@ public class NodeImpl implements Node, RaftServerService {
         final List<PeerId> peers = conf.listPeers();
         int aliveCount = 0;
         final Configuration deadNodes = new Configuration();
-        long minLastRpcSendTimestamp = Integer.MAX_VALUE;
+        long minLastRpcSendTimestamp = Long.MAX_VALUE;
         for (final PeerId peer : peers) {
             if (peer.equals(this.serverId)) {
                 aliveCount++;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1275,7 +1275,7 @@ public class NodeImpl implements Node, RaftServerService {
     }
 
     private boolean checkLeaderLease(final Configuration conf, final long monotonicNowMs) {
-        final List<PeerId> peers = conf.listPeers();
+        final List<PeerId> peers = conf.getPeers();
         int aliveCount = 0;
         for (final PeerId peer : peers) {
             if (peer.equals(this.serverId)) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
@@ -37,8 +37,8 @@ public class NodeOptions extends RpcOptions {
     private int              electionTimeoutMs      = 1000;                                         // follower to candidate timeout
 
     // Leader lease time's ratio of electionTimeoutMs
-    // Default: 90, Max: 100
-    private int              leaderLeaseTimeRatio   = 90;
+    // Default: 80, Max: 80
+    private int              leaderLeaseTimeRatio   = 80;
 
     // A snapshot saving would be triggered every |snapshot_interval_s| seconds
     // if this was reset as a positive number
@@ -191,15 +191,15 @@ public class NodeOptions extends RpcOptions {
     }
 
     public void setLeaderLeaseTimeRatio(int leaderLeaseTimeRatio) {
-        if (leaderLeaseTimeRatio <= 0 || leaderLeaseTimeRatio >= 100) {
+        if (leaderLeaseTimeRatio <= 0 || leaderLeaseTimeRatio > 80) {
             throw new IllegalArgumentException("leaderLeaseTimeRatio: " + leaderLeaseTimeRatio
-                                               + " (expected: 0 < leaderLeaseTimeRatio < 100)");
+                                               + " (expected: 0 < leaderLeaseTimeRatio <= 80)");
         }
         this.leaderLeaseTimeRatio = leaderLeaseTimeRatio;
     }
 
     public int getLeaderLeaseTimeoutMs() {
-        return getElectionTimeoutMs() * getLeaderLeaseTimeRatio() / 100;
+        return this.electionTimeoutMs * this.leaderLeaseTimeRatio / 100;
     }
 
     public int getSnapshotIntervalSecs() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
@@ -36,6 +36,10 @@ public class NodeOptions extends RpcOptions {
     // Default: 1000 (1s)
     private int              electionTimeoutMs      = 1000;                                         // follower to candidate timeout
 
+    // Leader lease time's ratio of electionTimeoutMs
+    // Default: 90, Max: 100
+    private int              leaderLeaseTimeRatio   = 90;
+
     // A snapshot saving would be triggered every |snapshot_interval_s| seconds
     // if this was reset as a positive number
     // If |snapshot_interval_s| <= 0, the time based snapshot would be disabled.
@@ -180,6 +184,22 @@ public class NodeOptions extends RpcOptions {
 
     public void setElectionTimeoutMs(int electionTimeoutMs) {
         this.electionTimeoutMs = electionTimeoutMs;
+    }
+
+    public int getLeaderLeaseTimeRatio() {
+        return leaderLeaseTimeRatio;
+    }
+
+    public void setLeaderLeaseTimeRatio(int leaderLeaseTimeRatio) {
+        if (leaderLeaseTimeRatio <= 0 || leaderLeaseTimeRatio >= 100) {
+            throw new IllegalArgumentException("leaderLeaseTimeRatio: " + leaderLeaseTimeRatio
+                                               + " (expected: 0 < leaderLeaseTimeRatio < 100)");
+        }
+        this.leaderLeaseTimeRatio = leaderLeaseTimeRatio;
+    }
+
+    public int getLeaderLeaseTimeoutMs() {
+        return getElectionTimeoutMs() * getLeaderLeaseTimeRatio() / 100;
     }
 
     public int getSnapshotIntervalSecs() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
@@ -36,9 +36,11 @@ public class NodeOptions extends RpcOptions {
     // Default: 1000 (1s)
     private int              electionTimeoutMs      = 1000;                                         // follower to candidate timeout
 
-    // Leader lease time's ratio of electionTimeoutMs
-    // Default: 80, Max: 80
-    private int              leaderLeaseTimeRatio   = 80;
+    // Leader lease time's ratio of electionTimeoutMs,
+    // To minimize the effects of clock drift, we should make that:
+    // clockDrift + leaderLeaseTimeoutMs < electionTimeout
+    // Default: 90, Max: 100
+    private int              leaderLeaseTimeRatio   = 90;
 
     // A snapshot saving would be triggered every |snapshot_interval_s| seconds
     // if this was reset as a positive number
@@ -191,9 +193,9 @@ public class NodeOptions extends RpcOptions {
     }
 
     public void setLeaderLeaseTimeRatio(int leaderLeaseTimeRatio) {
-        if (leaderLeaseTimeRatio <= 0 || leaderLeaseTimeRatio > 80) {
+        if (leaderLeaseTimeRatio <= 0 || leaderLeaseTimeRatio > 100) {
             throw new IllegalArgumentException("leaderLeaseTimeRatio: " + leaderLeaseTimeRatio
-                                               + " (expected: 0 < leaderLeaseTimeRatio <= 80)");
+                                               + " (expected: 0 < leaderLeaseTimeRatio <= 100)");
         }
         this.leaderLeaseTimeRatio = leaderLeaseTimeRatio;
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorTest.java
@@ -51,6 +51,7 @@ import com.alipay.sofa.jraft.storage.LogManager;
 import com.alipay.sofa.jraft.storage.SnapshotStorage;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.util.ThreadId;
+import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 
@@ -164,7 +165,7 @@ public class ReplicatorTest {
         id.unlock();
 
         Replicator.onRpcReturned(this.id, Replicator.RequestType.AppendEntries, new Status(-1, "test error"), request,
-            response, 0, 0, System.currentTimeMillis());
+            response, 0, 0, Utils.monotonicMs());
         assertEquals(r.statInfo.runningState, Replicator.RunningState.BLOCKING);
         assertNotNull(r.getBlockTimer());
     }
@@ -179,7 +180,7 @@ public class ReplicatorTest {
         id.unlock();
 
         Replicator.onRpcReturned(this.id, Replicator.RequestType.AppendEntries, Status.OK(), request, response, 0, 0,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
         Mockito.verify(this.node).increaseTermTo(
             2,
             new Status(RaftError.EHIGHERTERMRESPONSE, "Leader receives higher term hearbeat_response from peer:%s",
@@ -212,7 +213,7 @@ public class ReplicatorTest {
             .thenReturn(new FutureImpl<>());
 
         Replicator.onRpcReturned(this.id, Replicator.RequestType.AppendEntries, Status.OK(), request, response, 0, 0,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
 
         assertNotNull(r.getRpcInFly());
         assertNotSame(r.getRpcInFly(), rpcInFly);
@@ -247,7 +248,7 @@ public class ReplicatorTest {
             .thenReturn(new FutureImpl<>());
 
         Replicator.onRpcReturned(this.id, Replicator.RequestType.AppendEntries, Status.OK(), request, response, 0, 0,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
 
         assertNotNull(r.getRpcInFly());
         assertNotSame(r.getRpcInFly(), rpcInFly);
@@ -280,7 +281,7 @@ public class ReplicatorTest {
         });
 
         Replicator.onRpcReturned(this.id, Replicator.RequestType.AppendEntries, Status.OK(), request, response, 0, 0,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
 
         assertEquals(r.statInfo.runningState, Replicator.RunningState.IDLE);
         id.unlock();
@@ -395,7 +396,7 @@ public class ReplicatorTest {
         final ScheduledFuture<?> timer = r.getHeartbeatTimer();
         assertNotNull(timer);
         Replicator.onHeartbeatReturned(id, new Status(-1, "test"), this.createEmptyEntriesRequestt(), null,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
         assertNotNull(r.getHeartbeatTimer());
         assertNotSame(timer, r.getHeartbeatTimer());
     }
@@ -410,7 +411,7 @@ public class ReplicatorTest {
             setSuccess(false). //
             setLastLogIndex(10).setTerm(1).build();
         Replicator.onHeartbeatReturned(id, Status.OK(), this.createEmptyEntriesRequestt(), response,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
         assertNotNull(r.getHeartbeatTimer());
         assertNotSame(timer, r.getHeartbeatTimer());
     }
@@ -424,7 +425,7 @@ public class ReplicatorTest {
             setLastLogIndex(12).setTerm(2).build();
         id.unlock();
 
-        Replicator.onHeartbeatReturned(this.id, Status.OK(), request, response, System.currentTimeMillis());
+        Replicator.onHeartbeatReturned(this.id, Status.OK(), request, response, Utils.monotonicMs());
         Mockito.verify(this.node).increaseTermTo(
             2,
             new Status(RaftError.EHIGHERTERMRESPONSE, "Leader receives higher term hearbeat_response from peer:%s",
@@ -665,10 +666,10 @@ public class ReplicatorTest {
 
         assertTrue(r.getPendingResponses().isEmpty());
         Replicator.onRpcReturned(this.id, Replicator.RequestType.AppendEntries, Status.OK(), request, response, 1, 0,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
         assertEquals(1, r.getPendingResponses().size());
         Replicator.onRpcReturned(this.id, Replicator.RequestType.AppendEntries, Status.OK(), request, response, 0, 0,
-            System.currentTimeMillis());
+            Utils.monotonicMs());
         assertTrue(r.getPendingResponses().isEmpty());
         assertEquals(0, r.getWaitId());
         assertEquals(11, r.getRealNextIndex());


### PR DESCRIPTION
感谢阿里云的 静舟 提出以下这个 case：

leader的step down动作依赖timer，每隔0.5*ET检查一次；这个检查频率是不够的，会出双主问题；
举个实际例子，现有 A B C 三个节点，A是当前leader，ET为10秒，发生了以下事件：

| 时间戳  |     事件  |
|--------|---------|
| 0s         | 网络分区 (A B) (C) |
| 1s          | A check step down 通过，lease剩余10s |
| 6s         | A check step down 通过，lease剩余10s |
| 7s         | 网络分区 (A) (B C) |
| 9s         | C 选举超时，lease剩余1s，无动作 |
| 11s       | A check step down 通过，lease剩余6s |
| 16s       | A check step down 通过，lease剩余1s |
| 19s       | C 选举超时，此时B的lease已过期，因此prevote成功，vote成功，C升级为leader |
| 21s       | A check step down 失败，降级为follower |


从上面的时间线可以看到，19s～21s存在了两个leader，这段时间内的lease read有可能不满足线性一致性

解决思路：
思路一：
~~新增了一个 LeaderLeaseTimeout， 默认是 0.9 个 ElectionTimeout ， 在 readLeader() 时检查 lease，如果 lease timeout 了的话 就回退到 readIndex 读~~

思路二：
~~考虑到每次 lease read 都要循环检查一次的 cpu 开销，还是采用另一个方案：~~
~~LeaderLeaseTimeout 默认为 0.8 个 ElectionTimeout（ET），每 0.1 个 ET 定时调度更新 lastLeaderTimestamp， ， 在 readLeader() 时检查 lease，如果 lease timeout 了的话 就回退到 readIndex 读~~

最终方案：
类似方案一，新增了一个 LeaderLeaseTimeout， 默认是 0.9 个 ElectionTimeout ， 在 readLeader() 时检查 lease，如果 leaseTimeout 了的话， 重新检查 majority lastTimestamp 并更新 startLease，再次检查 startLease 如果仍然是 leaseTimeout 就回退到 readIndex 读
相比方案一，在 read 路径上尽量减少了 ”循环遍历检查 majority lastTimestamp“ ，另外在 stepDown 定时其中也会顺便更新 lastTimestamp

想强调一下的是，不是很建议开启 lease read，
对于 lease read，所有努力终将在一个时钟漂移中白费，jraft 中默认不开启 lease read，因为 jraft 的 readIndex 实现，性能足够满足一般要求，内部测试结果看吞吐接近 rpc 的极限