### PR TITLE
Feat/multi group snapshot

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/StateMachine.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/StateMachine.java
@@ -64,8 +64,8 @@ public interface StateMachine {
      * call done.run(status) when snapshot finished.
      * Default: Save nothing and returns error.
      *
-     * @param writer    snapshot writer
-     * @param done      callback
+     * @param writer snapshot writer
+     * @param done   callback
      */
     void onSnapshotSave(SnapshotWriter writer, Closure done);
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -1192,7 +1192,7 @@ public class Replicator implements ThreadId.OnError {
                 r.notifyOnCaughtUp(RaftError.EPERM.getNumber(), true);
                 r.destroy();
                 node.increaseTermTo(response.getTerm(), new Status(RaftError.EHIGHERTERMRESPONSE,
-                    "Leader receives higher term hearbeat_response from peer:%s", r.options.getPeerId()));
+                    "Leader receives higher term heartbeat_response from peer:%s", r.options.getPeerId()));
                 return false;
             }
             if (isLogDebugEnabled) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/Snapshot.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/Snapshot.java
@@ -38,7 +38,7 @@ public abstract class Snapshot extends Status {
      * Snapshot file prefix.
      */
     public static final String JRAFT_SNAPSHOT_PREFIX      = "snapshot_";
-    /** Snapshot uri scheme for remote peer*/
+    /** Snapshot uri scheme for remote peer */
     public static final String REMOTE_SNAPSHOT_URI_SCHEME = "remote://";
 
     /**

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorTest.java
@@ -183,7 +183,7 @@ public class ReplicatorTest {
             Utils.monotonicMs());
         Mockito.verify(this.node).increaseTermTo(
             2,
-            new Status(RaftError.EHIGHERTERMRESPONSE, "Leader receives higher term hearbeat_response from peer:%s",
+            new Status(RaftError.EHIGHERTERMRESPONSE, "Leader receives higher term heartbeat_response from peer:%s",
                 peerId));
         assertNull(r.id);
     }
@@ -428,7 +428,7 @@ public class ReplicatorTest {
         Replicator.onHeartbeatReturned(this.id, Status.OK(), request, response, Utils.monotonicMs());
         Mockito.verify(this.node).increaseTermTo(
             2,
-            new Status(RaftError.EHIGHERTERMRESPONSE, "Leader receives higher term hearbeat_response from peer:%s",
+            new Status(RaftError.EHIGHERTERMRESPONSE, "Leader receives higher term heartbeat_response from peer:%s",
                 peerId));
         assertNull(r.id);
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
@@ -449,10 +449,11 @@ public class DefaultRegionKVService implements RegionKVService {
         try {
             checkRegionEpoch(request);
             final byte[] key = requireNonNull(request.getKey(), "lock.key");
+            final byte[] fencingKey = this.regionEngine.getRegion().getStartKey();
             final DistributedLock.Acquirer acquirer = requireNonNull(request.getAcquirer(), "lock.acquirer");
             requireNonNull(acquirer.getId(), "lock.id");
             requirePositive(acquirer.getLeaseMillis(), "lock.leaseMillis");
-            this.rawKVStore.tryLockWith(key, request.isKeepLease(), acquirer, new BaseKVStoreClosure() {
+            this.rawKVStore.tryLockWith(key, fencingKey, request.isKeepLease(), acquirer, new BaseKVStoreClosure() {
 
                 @Override
                 public void run(Status status) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/RegionEngine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/RegionEngine.java
@@ -85,7 +85,7 @@ public class RegionEngine implements Lifecycle<RegionEngineOptions> {
             return true;
         }
         this.regionOpts = Requires.requireNonNull(opts, "opts");
-        this.fsm = new KVStoreStateMachine(this.region.getId(), this.storeEngine);
+        this.fsm = new KVStoreStateMachine(this.region, this.storeEngine);
 
         // node options
         NodeOptions nodeOpts = opts.getNodeOptions();

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngine.java
@@ -515,11 +515,7 @@ public class StoreEngine implements Lifecycle<StoreEngineOptions> {
             rOpts.setRaftDataPath(baseRaftDataPath + "raft_data_region_" + region.getId() + "_"
                                   + getSelfEndpoint().getPort());
             final RegionEngine engine = new RegionEngine(region, this);
-            if (engine.init(rOpts)) {
-                final RegionKVService regionKVService = new DefaultRegionKVService(engine);
-                registerRegionKVService(regionKVService);
-                this.regionEngineTable.put(region.getId(), engine);
-            } else {
+            if (!engine.init(rOpts)) {
                 LOG.error("Fail to init [RegionEngine: {}].", region);
                 if (closure != null) {
                     // null on follower
@@ -528,12 +524,16 @@ public class StoreEngine implements Lifecycle<StoreEngineOptions> {
                 }
                 return;
             }
+
             // update parent conf
             final Region pRegion = parent.getRegion();
             final RegionEpoch pEpoch = pRegion.getRegionEpoch();
             final long version = pEpoch.getVersion();
             pEpoch.setVersion(version + 1); // version + 1
             pRegion.setEndKey(splitKey); // update endKey
+
+            this.regionEngineTable.put(region.getId(), engine);
+            registerRegionKVService(new DefaultRegionKVService(engine));
             // update local regionRouteTable
             this.pdClient.getRegionRouteTable().splitRegion(pRegion.getId(), region);
             if (closure != null) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngine.java
@@ -532,8 +532,12 @@ public class StoreEngine implements Lifecycle<StoreEngineOptions> {
             pEpoch.setVersion(version + 1); // version + 1
             pRegion.setEndKey(splitKey); // update endKey
 
+            // the following two lines of code can make a relation of 'happens-before' for
+            // read 'pRegion', because that a write to a ConcurrentMap happens-before every
+            // subsequent read of that ConcurrentMap.
             this.regionEngineTable.put(region.getId(), engine);
             registerRegionKVService(new DefaultRegionKVService(engine));
+
             // update local regionRouteTable
             this.pdClient.getRegionRouteTable().splitRegion(pRegion.getId(), region);
             if (closure != null) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -1165,7 +1165,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
                 retryRunner);
         if (regionEngine != null) {
             if (ensureOnValidEpoch(region, regionEngine, closure)) {
-                getRawKVStore(regionEngine).tryLockWith(key, keepLease, acquirer, closure);
+                getRawKVStore(regionEngine).tryLockWith(key, region.getStartKey(), keepLease, acquirer, closure);
             }
         } else {
             final KeyLockRequest request = new KeyLockRequest();

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+import java.util.zip.ZipOutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alipay.sofa.jraft.Closure;
+import com.alipay.sofa.jraft.Status;
+import com.alipay.sofa.jraft.error.RaftError;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
+import com.alipay.sofa.jraft.rhea.serialization.Serializer;
+import com.alipay.sofa.jraft.rhea.serialization.Serializers;
+import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
+import com.alipay.sofa.jraft.rhea.util.ZipUtil;
+import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
+import com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter;
+import com.google.protobuf.ByteString;
+
+import static com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
+
+/**
+ * @author jiachun.fjc
+ */
+public abstract class AbstractKVStoreSnapshotFile implements KVStoreSnapshotFile {
+
+    private static final Logger LOG              = LoggerFactory.getLogger(AbstractKVStoreSnapshotFile.class);
+
+    private static final String SNAPSHOT_DIR     = "kv";
+    private static final String SNAPSHOT_ARCHIVE = "kv.zip";
+
+    protected final Serializer  serializer       = Serializers.getDefault();
+
+    @Override
+    public void save(final SnapshotWriter writer, final Closure done, final Region region,
+                     final ExecutorService executor) {
+        final String writerPath = writer.getPath();
+        final String snapshotPath = Paths.get(writerPath, SNAPSHOT_DIR).toString();
+        try {
+            final LocalFileMeta meta = doSnapshotSave(snapshotPath, region);
+            executor.execute(() -> compressSnapshot(writer, meta, done));
+        } catch (final Throwable t) {
+            LOG.error("Fail to save snapshot, path={}, file list={}, {}.", writerPath, writer.listFiles(),
+                    StackTraceUtil.stackTrace(t));
+            done.run(new Status(RaftError.EIO, "Fail to save snapshot at %s, error is %s", writerPath,
+                    t.getMessage()));
+        }
+    }
+
+    @Override
+    public boolean load(final SnapshotReader reader, final Region region) {
+        final LocalFileMeta meta = (LocalFileMeta) reader.getFileMeta(SNAPSHOT_ARCHIVE);
+        final String readerPath = reader.getPath();
+        if (meta == null) {
+            LOG.error("Can't find kv snapshot file, path={}.", readerPath);
+            return false;
+        }
+        final String snapshotPath = Paths.get(readerPath, SNAPSHOT_DIR).toString();
+        try {
+            decompressSnapshot(readerPath);
+            doSnapshotLoad(snapshotPath, meta, region);
+            return true;
+        } catch (final Throwable t) {
+            LOG.error("Fail to load snapshot, path={}, file list={}, {}.", readerPath, reader.listFiles(),
+                StackTraceUtil.stackTrace(t));
+            return false;
+        }
+    }
+
+    abstract LocalFileMeta doSnapshotSave(final String snapshotPath, final Region region) throws Exception;
+
+    abstract void doSnapshotLoad(final String snapshotPath, final LocalFileMeta meta, final Region region)
+                                                                                                          throws Exception;
+
+    protected void compressSnapshot(final SnapshotWriter writer, final LocalFileMeta meta, final Closure done) {
+        final String writerPath = writer.getPath();
+        final String outputFile = Paths.get(writerPath, SNAPSHOT_ARCHIVE).toString();
+        try {
+            try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(outputFile))) {
+                ZipUtil.compressDirectoryToZipFile(writerPath, SNAPSHOT_DIR, out);
+            }
+            if (writer.addFile(SNAPSHOT_ARCHIVE, meta)) {
+                done.run(Status.OK());
+            } else {
+                done.run(new Status(RaftError.EIO, "Fail to add snapshot file: %s", writerPath));
+            }
+        } catch (final Throwable t) {
+            LOG.error("Fail to compress snapshot, path={}, file list={}, {}.", writerPath, writer.listFiles(),
+                StackTraceUtil.stackTrace(t));
+            done.run(new Status(RaftError.EIO, "Fail to compress snapshot at %s, error is %s", writerPath, t
+                .getMessage()));
+        }
+    }
+
+    protected void decompressSnapshot(final String readerPath) throws IOException {
+        final String sourceFile = Paths.get(readerPath, SNAPSHOT_ARCHIVE).toString();
+        ZipUtil.unzipFile(sourceFile, readerPath);
+    }
+
+    protected <T> T readMetadata(final LocalFileMeta meta, final Class<T> cls) {
+        final ByteString userMeta = meta.getUserMeta();
+        return this.serializer.readObject(userMeta.toByteArray(), cls);
+    }
+
+    protected <T> LocalFileMeta buildMetadata(final T metadata) {
+        return metadata == null ? null : LocalFileMeta.newBuilder() //
+            .setUserMeta(ByteString.copyFrom(this.serializer.writeObject(metadata))) //
+            .build();
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
@@ -25,6 +25,7 @@ import com.alipay.sofa.jraft.Lifecycle;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.error.RaftError;
 import com.alipay.sofa.jraft.rhea.errors.Errors;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.metrics.KVMetrics;
 import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
 import com.alipay.sofa.jraft.util.BytesUtil;
@@ -96,9 +97,10 @@ public abstract class BaseRawKVStore<T> implements RawKVStore, Lifecycle<T> {
      */
     public abstract byte[] jumpOver(final byte[] startKey, final long distance);
 
-    public abstract LocalFileMeta onSnapshotSave(final String snapshotPath) throws Exception;
+    public abstract LocalFileMeta onSnapshotSave(final String snapshotPath, final Region region) throws Exception;
 
-    public abstract void onSnapshotLoad(final String snapshotPath, final LocalFileMeta meta) throws Exception;
+    public abstract void onSnapshotLoad(final String snapshotPath, final LocalFileMeta meta, final Region region)
+                                                                                                                 throws Exception;
 
     // static methods
     //

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
@@ -28,7 +28,6 @@ import com.alipay.sofa.jraft.rhea.errors.Errors;
 import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.metrics.KVMetrics;
 import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
-import com.alipay.sofa.jraft.util.BytesUtil;
 import com.codahale.metrics.Timer;
 
 import static com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
@@ -38,8 +37,6 @@ import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.DB_TIMER;
  * @author jiachun.fjc
  */
 public abstract class BaseRawKVStore<T> implements RawKVStore, Lifecycle<T> {
-
-    protected static final byte[] LOCK_FENCING_KEY = BytesUtil.writeUtf8("LOCK_FENCING_KEY");
 
     @Override
     public void get(final byte[] key, final KVStoreClosure closure) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
@@ -94,8 +94,22 @@ public abstract class BaseRawKVStore<T> implements RawKVStore, Lifecycle<T> {
      */
     public abstract byte[] jumpOver(final byte[] startKey, final long distance);
 
+    /**
+     * Init the fencing token of new region.
+     *
+     * @param parentKey the fencing key of parent region
+     * @param childKey  the fencing key of new region
+     */
+    public abstract void initFencingToken(final byte[] parentKey, final byte[] childKey);
+
+    /**
+     * Save snapshot of current region.
+     */
     public abstract LocalFileMeta onSnapshotSave(final String snapshotPath, final Region region) throws Exception;
 
+    /**
+     * Load snapshot of current region.
+     */
     public abstract void onSnapshotLoad(final String snapshotPath, final LocalFileMeta meta, final Region region)
                                                                                                                  throws Exception;
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
@@ -25,12 +25,10 @@ import com.alipay.sofa.jraft.Lifecycle;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.error.RaftError;
 import com.alipay.sofa.jraft.rhea.errors.Errors;
-import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.metrics.KVMetrics;
 import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
 import com.codahale.metrics.Timer;
 
-import static com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
 import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.DB_TIMER;
 
 /**
@@ -101,17 +99,6 @@ public abstract class BaseRawKVStore<T> implements RawKVStore, Lifecycle<T> {
      * @param childKey  the fencing key of new region
      */
     public abstract void initFencingToken(final byte[] parentKey, final byte[] childKey);
-
-    /**
-     * Save snapshot of current region.
-     */
-    public abstract LocalFileMeta onSnapshotSave(final String snapshotPath, final Region region) throws Exception;
-
-    /**
-     * Load snapshot of current region.
-     */
-    public abstract void onSnapshotLoad(final String snapshotPath, final LocalFileMeta meta, final Region region)
-                                                                                                                 throws Exception;
 
     // static methods
     //

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BatchRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BatchRawKVStore.java
@@ -85,7 +85,8 @@ public abstract class BatchRawKVStore<T> extends BaseRawKVStore<T> {
             final KVState kvState = kvStates.get(i);
             final KVOperation op = kvState.getOp();
             final Pair<Boolean, DistributedLock.Acquirer> acquirerPair = op.getAcquirerPair();
-            tryLockWith(op.getKey(), acquirerPair.getKey(), acquirerPair.getValue(), kvState.getDone());
+            tryLockWith(op.getKey(), op.getFencingKey(), acquirerPair.getKey(), acquirerPair.getValue(),
+                kvState.getDone());
         }
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVOperation.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVOperation.java
@@ -155,10 +155,10 @@ public class KVOperation implements Serializable {
         return new KVOperation(BytesUtil.EMPTY_BYTES, BytesUtil.EMPTY_BYTES, nodeExecutor, NODE_EXECUTE);
     }
 
-    public static KVOperation createKeyLockRequest(final byte[] key,
+    public static KVOperation createKeyLockRequest(final byte[] key, final byte[] fencingKey,
                                                    final Pair<Boolean, DistributedLock.Acquirer> acquirerPair) {
         Requires.requireNonNull(key, "key");
-        return new KVOperation(key, BytesUtil.EMPTY_BYTES, acquirerPair, KEY_LOCK);
+        return new KVOperation(key, fencingKey, acquirerPair, KEY_LOCK);
     }
 
     public static KVOperation createKeyLockReleaseRequest(final byte[] key, final DistributedLock.Acquirer acquirer) {
@@ -236,6 +236,10 @@ public class KVOperation implements Serializable {
     }
 
     public byte[] getEndKey() {
+        return value;
+    }
+
+    public byte[] getFencingKey() {
         return value;
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreSnapshotFile.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage;
+
+import java.util.concurrent.ExecutorService;
+
+import com.alipay.sofa.jraft.Closure;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
+import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
+import com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public interface KVStoreSnapshotFile {
+
+    /**
+     * Save a snapshot for the specified region.
+     *
+     * @param writer snapshot writer
+     * @param done   callback
+     * @param region the region to save snapshot
+     */
+    void save(final SnapshotWriter writer, final Closure done, final Region region, final ExecutorService executor);
+
+    /**
+     * Load snapshot for the specified region.
+     *
+     * @param reader snapshot writer
+     * @param region the region to load snapshot
+     * @return if load succeed
+     */
+    boolean load(final SnapshotReader reader, final Region region);
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreSnapshotFile.java
@@ -32,18 +32,19 @@ public interface KVStoreSnapshotFile {
     /**
      * Save a snapshot for the specified region.
      *
-     * @param writer snapshot writer
-     * @param done   callback
-     * @param region the region to save snapshot
+     * @param writer   snapshot writer
+     * @param done     callback
+     * @param region   the region to save snapshot
+     * @param executor the executor to compress snapshot
      */
     void save(final SnapshotWriter writer, final Closure done, final Region region, final ExecutorService executor);
 
     /**
      * Load snapshot for the specified region.
      *
-     * @param reader snapshot writer
+     * @param reader snapshot reader
      * @param region the region to load snapshot
-     * @return if load succeed
+     * @return true if load succeed
      */
     boolean load(final SnapshotReader reader, final Region region);
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreSnapshotFileFactory.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreSnapshotFileFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage;
+
+import com.alipay.sofa.jraft.util.Requires;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public final class KVStoreSnapshotFileFactory {
+
+    public static <T> KVStoreSnapshotFile getKVStoreSnapshotFile(final BaseRawKVStore<T> kvStore) {
+        Requires.requireNonNull(kvStore, "kvStore");
+        if (kvStore instanceof RocksRawKVStore) {
+            return new RocksKVStoreSnapshotFile((RocksRawKVStore) kvStore);
+        }
+        if (kvStore instanceof MemoryRawKVStore) {
+            return new MemoryKVStoreSnapshotFile((MemoryRawKVStore) kvStore);
+        }
+        throw reject("fail to find a KVStoreSnapshotFile with " + kvStore.getClass().getName());
+    }
+
+    private static UnsupportedOperationException reject(final String message) {
+        return new UnsupportedOperationException(message);
+    }
+
+    private KVStoreSnapshotFileFactory() {
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.jraft.rhea.storage;
 
 import java.io.FileOutputStream;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
@@ -208,6 +209,8 @@ public class KVStoreStateMachine extends StateMachineAdapter {
                 this.rawKVStore.initFencingToken(parentKey, splitKey);
                 this.storeEngine.doSplit(regionIds.getKey(), regionIds.getValue(), splitKey, closure);
             } catch (final Exception e) {
+                LOG.error("Fail to split, regionId={}, newRegionId={}, splitKey={}.", regionIds.getKey(),
+                    regionIds.getValue(), Arrays.toString(splitKey));
                 if (closure != null) {
                     // closure is null on follower node
                     closure.setError(Errors.STORAGE_ERROR);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryKVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryKVStoreSnapshotFile.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+
+import com.alipay.sofa.jraft.rhea.errors.StorageException;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
+import com.alipay.sofa.jraft.rhea.util.ByteArray;
+import com.alipay.sofa.jraft.rhea.util.Pair;
+import com.alipay.sofa.jraft.rhea.util.RegionHelper;
+import com.alipay.sofa.jraft.rhea.util.concurrent.DistributedLock;
+import com.alipay.sofa.jraft.util.Bits;
+
+import static com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class MemoryKVStoreSnapshotFile extends AbstractKVStoreSnapshotFile {
+
+    private final MemoryRawKVStore kvStore;
+
+    MemoryKVStoreSnapshotFile(MemoryRawKVStore kvStore) {
+        this.kvStore = kvStore;
+    }
+
+    @Override
+    LocalFileMeta doSnapshotSave(final String snapshotPath, final Region region) throws Exception {
+        final File file = new File(snapshotPath);
+        FileUtils.deleteDirectory(file);
+        FileUtils.forceMkdir(file);
+        this.kvStore.doSnapshotSave(this, snapshotPath, region);
+        return buildMetadata(region);
+    }
+
+    @Override
+    void doSnapshotLoad(final String snapshotPath, final LocalFileMeta meta, final Region region) throws Exception {
+        final File file = new File(snapshotPath);
+        if (!file.exists()) {
+            throw new StorageException("Snapshot file [" + snapshotPath + "] not exists");
+        }
+        final Region snapshotRegion = readMetadata(meta, Region.class);
+        if (!RegionHelper.isSameRange(region, snapshotRegion)) {
+            throw new StorageException("Invalid snapshot region: " + snapshotRegion + ", current region is: " + region);
+        }
+        this.kvStore.doSnapshotLoad(this, snapshotPath);
+    }
+
+    <T> void writeToFile(final String rootPath, final String fileName, final Persistence<T> persist) throws Exception {
+        final Path path = Paths.get(rootPath, fileName);
+        try (final FileOutputStream out = new FileOutputStream(path.toFile());
+                final BufferedOutputStream bufOutput = new BufferedOutputStream(out)) {
+            final byte[] bytes = this.serializer.writeObject(persist);
+            final byte[] lenBytes = new byte[4];
+            Bits.putInt(lenBytes, 0, bytes.length);
+            bufOutput.write(lenBytes);
+            bufOutput.write(bytes);
+            bufOutput.flush();
+            out.getFD().sync();
+        }
+    }
+
+    <T> T readFromFile(final String rootPath, final String fileName, final Class<T> clazz) throws Exception {
+        final Path path = Paths.get(rootPath, fileName);
+        final File file = path.toFile();
+        if (!file.exists()) {
+            throw new NoSuchFieldException(path.toString());
+        }
+        try (final FileInputStream in = new FileInputStream(file);
+                final BufferedInputStream bufInput = new BufferedInputStream(in)) {
+            final byte[] lenBytes = new byte[4];
+            int read = bufInput.read(lenBytes);
+            if (read != lenBytes.length) {
+                throw new IOException("fail to read snapshot file length, expects " + lenBytes.length
+                                      + " bytes, but read " + read);
+            }
+            final int len = Bits.getInt(lenBytes, 0);
+            final byte[] bytes = new byte[len];
+            read = bufInput.read(bytes);
+            if (read != bytes.length) {
+                throw new IOException("fail to read snapshot file, expects " + bytes.length + " bytes, but read "
+                                      + read);
+            }
+            return this.serializer.readObject(bytes, clazz);
+        }
+    }
+
+    static class Persistence<T> {
+
+        private final T data;
+
+        public Persistence(T data) {
+            this.data = data;
+        }
+
+        public T data() {
+            return data;
+        }
+    }
+
+    /**
+     * The data of sequences
+     */
+    static class SequenceDB extends Persistence<Map<ByteArray, Long>> {
+
+        public SequenceDB(Map<ByteArray, Long> data) {
+            super(data);
+        }
+    }
+
+    /**
+     * The data of fencing token keys
+     */
+    static class FencingKeyDB extends Persistence<Map<ByteArray, Long>> {
+
+        public FencingKeyDB(Map<ByteArray, Long> data) {
+            super(data);
+        }
+    }
+
+    /**
+     * The data of lock info
+     */
+    static class LockerDB extends Persistence<Map<ByteArray, DistributedLock.Owner>> {
+
+        public LockerDB(Map<ByteArray, DistributedLock.Owner> data) {
+            super(data);
+        }
+    }
+
+    /**
+     * The data will be cut into many small portions, each called a segment
+     */
+    static class Segment extends Persistence<List<Pair<byte[], byte[]>>> {
+
+        public Segment(List<Pair<byte[], byte[]>> data) {
+            super(data);
+        }
+    }
+
+    /**
+     * The 'tailIndex' records the largest segment number (the segment number starts from 0)
+     */
+    static class TailIndex extends Persistence<Integer> {
+
+        public TailIndex(Integer data) {
+            super(data);
+        }
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
@@ -663,12 +663,12 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
         try {
             final File file = new File(snapshotPath);
             if (!file.exists()) {
-                throw new StorageException("Snapshot file [" + snapshotPath + "] not exists.");
+                throw new StorageException("Snapshot file [" + snapshotPath + "] not exists");
             }
             final ByteString userMeta = meta.getUserMeta();
             final Region snapshotRegion = this.serializer.readObject(userMeta.toByteArray(), Region.class);
             if (!RegionHelper.isSameRange(region, snapshotRegion)) {
-                throw new StorageException("Invalid snapshot region: " + snapshotRegion + " current region is: "
+                throw new StorageException("Invalid snapshot region: " + snapshotRegion + ", current region is: "
                                            + region);
             }
             final SequenceDB sequenceDB = readFromFile(snapshotPath, "sequenceDB", SequenceDB.class);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
@@ -621,10 +621,10 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
                                                                                                                      throws Exception {
         final Timer.Context timeCtx = getTimeContext("SNAPSHOT_SAVE");
         try {
-            snapshotFile.writeToFile(snapshotPath, "sequenceDB", new SequenceDB(copySubRange(this.sequenceDB, region)));
+            snapshotFile.writeToFile(snapshotPath, "sequenceDB", new SequenceDB(subRangeMap(this.sequenceDB, region)));
             snapshotFile.writeToFile(snapshotPath, "fencingKeyDB",
-                new FencingKeyDB(copySubRange(this.fencingKeyDB, region)));
-            snapshotFile.writeToFile(snapshotPath, "lockerDB", new LockerDB(copySubRange(this.lockerDB, region)));
+                new FencingKeyDB(subRangeMap(this.fencingKeyDB, region)));
+            snapshotFile.writeToFile(snapshotPath, "lockerDB", new LockerDB(subRangeMap(this.lockerDB, region)));
             final int size = this.opts.getKeysPerSegment();
             final List<Pair<byte[], byte[]>> segment = Lists.newArrayListWithCapacity(size);
             int index = 0;
@@ -681,7 +681,7 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
         }
     }
 
-    static <V> Map<ByteArray, V> copySubRange(final Map<ByteArray, V> input, final Region region) {
+    static <V> Map<ByteArray, V> subRangeMap(final Map<ByteArray, V> input, final Region region) {
         if (RegionHelper.isSingleGroup(region)) {
             return input;
         }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
@@ -329,7 +329,7 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
                         // first time to acquire and success
                         .remainingMillis(DistributedLock.OwnerBuilder.FIRST_TIME_SUCCESS)
                         // create a new fencing token
-                        .fencingToken(getNextFencingToken(LOCK_FENCING_KEY))
+                        .fencingToken(getNextFencingToken(key))
                         // init acquires
                         .acquires(1)
                         // set acquirer ctx
@@ -368,7 +368,7 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
                         // success as a new acquirer
                         .remainingMillis(DistributedLock.OwnerBuilder.NEW_ACQUIRE_SUCCESS)
                         // create a new fencing token
-                        .fencingToken(getNextFencingToken(LOCK_FENCING_KEY))
+                        .fencingToken(getNextFencingToken(key))
                         // init acquires
                         .acquires(1)
                         // set acquirer ctx
@@ -519,7 +519,6 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
         }
     }
 
-    @SuppressWarnings("SameParameterValue")
     private long getNextFencingToken(final byte[] fencingKey) {
         final Timer.Context timeCtx = getTimeContext("FENCING_TOKEN");
         try {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsRawKVStore.java
@@ -153,11 +153,11 @@ public class MetricsRawKVStore implements RawKVStore {
     }
 
     @Override
-    public void tryLockWith(final byte[] key, final boolean keepLease, final DistributedLock.Acquirer acquirer,
-                            final KVStoreClosure closure) {
+    public void tryLockWith(final byte[] key, final byte[] fencingKey, final boolean keepLease,
+                            final DistributedLock.Acquirer acquirer, final KVStoreClosure closure) {
         // 'keysCount' and 'bytesWritten' can't be provided with exact numbers, but I endured
         final KVStoreClosure c = metricsAdapter(closure, KEY_LOCK, 2, 0);
-        this.rawKVStore.tryLockWith(key, keepLease, acquirer, c);
+        this.rawKVStore.tryLockWith(key, fencingKey, keepLease, acquirer, c);
     }
 
     @Override

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RaftRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RaftRawKVStore.java
@@ -209,14 +209,14 @@ public class RaftRawKVStore implements RawKVStore {
     }
 
     @Override
-    public void tryLockWith(final byte[] key, final boolean keepLease, final DistributedLock.Acquirer acquirer,
-                            final KVStoreClosure closure) {
+    public void tryLockWith(final byte[] key, final byte[] fencingKey, final boolean keepLease,
+                            final DistributedLock.Acquirer acquirer, final KVStoreClosure closure) {
         // The algorithm relies on the assumption that while there is no
         // synchronized clock across the processes, still the local time in
         // every process flows approximately at the same rate, with an error
         // which is small compared to the auto-release time of the lock.
         acquirer.setLockingTimestamp(Clock.defaultClock().getTime());
-        applyOperation(KVOperation.createKeyLockRequest(key, Pair.of(keepLease, acquirer)), closure);
+        applyOperation(KVOperation.createKeyLockRequest(key, fencingKey, Pair.of(keepLease, acquirer)), closure);
     }
 
     @Override

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RawKVStore.java
@@ -154,8 +154,8 @@ public interface RawKVStore {
     /**
      * Tries to lock the specified key, must contain a timeout
      */
-    void tryLockWith(final byte[] key, final boolean keepLease, final DistributedLock.Acquirer acquirer,
-                     final KVStoreClosure closure);
+    void tryLockWith(final byte[] key, final byte[] fencingKey, final boolean keepLease,
+                     final DistributedLock.Acquirer acquirer, final KVStoreClosure closure);
 
     /**
      * Unlock the specified key with lock.

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksKVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksKVStoreSnapshotFile.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage;
+
+import com.alipay.sofa.jraft.rhea.errors.StorageException;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
+import com.alipay.sofa.jraft.rhea.util.RegionHelper;
+
+import static com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class RocksKVStoreSnapshotFile extends AbstractKVStoreSnapshotFile {
+
+    private final RocksRawKVStore kvStore;
+
+    RocksKVStoreSnapshotFile(RocksRawKVStore kvStore) {
+        this.kvStore = kvStore;
+    }
+
+    @Override
+    LocalFileMeta doSnapshotSave(final String snapshotPath, final Region region) throws Exception {
+        if (RegionHelper.isMultiGroup(region)) {
+            this.kvStore.writeSstSnapshot(snapshotPath, region);
+            return buildMetadata(region);
+        }
+        if (this.kvStore.isFastSnapshot()) {
+            this.kvStore.writeSnapshot(snapshotPath);
+            return null;
+        }
+        final RocksDBBackupInfo backupInfo = this.kvStore.backupDB(snapshotPath);
+        return buildMetadata(backupInfo);
+    }
+
+    @Override
+    void doSnapshotLoad(final String snapshotPath, final LocalFileMeta meta, final Region region) throws Exception {
+        if (RegionHelper.isMultiGroup(region)) {
+            final Region snapshotRegion = readMetadata(meta, Region.class);
+            if (!RegionHelper.isSameRange(region, snapshotRegion)) {
+                throw new StorageException("Invalid snapshot region: " + snapshotRegion + " current region is: "
+                                           + region);
+            }
+            this.kvStore.readSstSnapshot(snapshotPath);
+            return;
+        }
+        if (this.kvStore.isFastSnapshot()) {
+            this.kvStore.readSnapshot(snapshotPath);
+            return;
+        }
+        final RocksDBBackupInfo rocksBackupInfo = readMetadata(meta, RocksDBBackupInfo.class);
+        this.kvStore.restoreBackup(snapshotPath, rocksBackupInfo);
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -63,6 +63,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alipay.sofa.jraft.rhea.errors.StorageException;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.options.RocksDBOptions;
 import com.alipay.sofa.jraft.rhea.rocks.support.RocksStatisticsCollector;
 import com.alipay.sofa.jraft.rhea.serialization.Serializer;
@@ -1023,7 +1024,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
     }
 
     @Override
-    public LocalFileMeta onSnapshotSave(final String snapshotPath) throws Exception {
+    public LocalFileMeta onSnapshotSave(final String snapshotPath, final Region region) throws Exception {
         if (this.opts.isFastSnapshot()) {
             FileUtils.deleteDirectory(new File(snapshotPath));
             writeSnapshot(snapshotPath);
@@ -1035,7 +1036,8 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
     }
 
     @Override
-    public void onSnapshotLoad(final String snapshotPath, final LocalFileMeta meta) throws Exception {
+    public void onSnapshotLoad(final String snapshotPath, final LocalFileMeta meta, final Region region)
+                                                                                                        throws Exception {
         if (this.opts.isFastSnapshot()) {
             readSnapshot(snapshotPath);
         } else {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -1161,8 +1161,9 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             final RocksDBBackupInfo rocksBackupInfo = new RocksDBBackupInfo(backupInfo);
             LOG.info("Backup rocksDB into {} with backupInfo {}.", backupDBPath, rocksBackupInfo);
 
+            final byte[] metaBytes = this.serializer.writeObject(rocksBackupInfo);
             return LocalFileMeta.newBuilder() //
-                    .setUserMeta(ByteString.copyFrom(this.serializer.writeObject(rocksBackupInfo))) //
+                    .setUserMeta(ByteString.copyFrom(metaBytes)) //
                     .build();
         } catch (final RocksDBException e) {
             throw new StorageException("Fail to backup at path: " + backupDBPath, e);
@@ -1274,8 +1275,9 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                 throw new StorageException("Fail to rename [" + tempPath + "] to [" + snapshotPath + "].");
             }
 
+            final byte[] metaBytes = this.serializer.writeObject(region);
             return LocalFileMeta.newBuilder() //
-                .setUserMeta(ByteString.copyFrom(this.serializer.writeObject(region))) //
+                .setUserMeta(ByteString.copyFrom(metaBytes)) //
                 .build();
         } catch (final Exception e) {
             throw new StorageException("Fail to do read sst snapshot at path: " + snapshotPath, e);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -649,7 +649,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                         // first time to acquire and success
                         .remainingMillis(DistributedLock.OwnerBuilder.FIRST_TIME_SUCCESS)
                         // create a new fencing token
-                        .fencingToken(getNextFencingToken(LOCK_FENCING_KEY))
+                        .fencingToken(getNextFencingToken(key))
                         // init acquires
                         .acquires(1)
                         // set acquirer ctx
@@ -690,7 +690,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                         // success as a new acquirer
                         .remainingMillis(DistributedLock.OwnerBuilder.NEW_ACQUIRE_SUCCESS)
                         // create a new fencing token
-                        .fencingToken(getNextFencingToken(LOCK_FENCING_KEY))
+                        .fencingToken(getNextFencingToken(key))
                         // init acquires
                         .acquires(1)
                         // set acquirer ctx
@@ -847,7 +847,6 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
         }
     }
 
-    @SuppressWarnings("SameParameterValue")
     private long getNextFencingToken(final byte[] fencingKey) throws RocksDBException {
         final Timer.Context timeCtx = getTimeContext("FENCING_TOKEN");
         final Lock readLock = this.readWriteLock.readLock();

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -1101,8 +1101,8 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                         sstFileWriter.close();
                     } else {
                         sstFileWriter.finish();
-                        LOG.info("Finish sst file {} with {} keys.", sstFile, count);
                     }
+                    LOG.info("Finish sst file {} with {} keys.", sstFile, count);
                 } catch (final RocksDBException e) {
                     throw new StorageException("Fail to create sst file at path: " + sstFile, e);
                 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -79,6 +79,7 @@ import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
 import com.alipay.sofa.jraft.rhea.util.concurrent.DistributedLock;
 import com.alipay.sofa.jraft.util.Bits;
 import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.StorageOptionsFactory;
 import com.alipay.sofa.jraft.util.SystemPropertyUtil;
 import com.codahale.metrics.Timer;
@@ -1079,9 +1080,8 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
     }
 
     public void addStatisticsCollectorCallback(final StatisticsCollectorCallback callback) {
-        if (this.statisticsCollector == null || this.statistics == null) {
-            throw new IllegalStateException("statistics collector is not running");
-        }
+        Requires.requireNonNull(this.statisticsCollector, "statisticsCollector");
+        Requires.requireNonNull(this.statistics, "statistics");
         this.statisticsCollector.addStatsCollectorInput(new StatsCollectorInput(this.statistics, callback));
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -1159,10 +1159,11 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             // chose the backupInfo who has max backupId
             final BackupInfo backupInfo = Collections.max(backupInfoList, Comparator.comparingInt(BackupInfo::backupId));
             final RocksDBBackupInfo rocksBackupInfo = new RocksDBBackupInfo(backupInfo);
-            final LocalFileMeta.Builder fb = LocalFileMeta.newBuilder();
-            fb.setUserMeta(ByteString.copyFrom(this.serializer.writeObject(rocksBackupInfo)));
             LOG.info("Backup rocksDB into {} with backupInfo {}.", backupDBPath, rocksBackupInfo);
-            return fb.build();
+
+            return LocalFileMeta.newBuilder() //
+                    .setUserMeta(ByteString.copyFrom(this.serializer.writeObject(rocksBackupInfo))) //
+                    .build();
         } catch (final RocksDBException e) {
             throw new StorageException("Fail to backup at path: " + backupDBPath, e);
         } finally {
@@ -1272,9 +1273,10 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             if (!tempFile.renameTo(snapshotFile)) {
                 throw new StorageException("Fail to rename [" + tempPath + "] to [" + snapshotPath + "].");
             }
-            final LocalFileMeta.Builder fb = LocalFileMeta.newBuilder();
-            fb.setUserMeta(ByteString.copyFrom(this.serializer.writeObject(region)));
-            return fb.build();
+
+            return LocalFileMeta.newBuilder() //
+                .setUserMeta(ByteString.copyFrom(this.serializer.writeObject(region))) //
+                .build();
         } catch (final Exception e) {
             throw new StorageException("Fail to do read sst snapshot at path: " + snapshotPath, e);
         } finally {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -1147,8 +1147,8 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
         FileUtils.forceMkdir(new File(backupDBPath));
         final Lock writeLock = this.readWriteLock.writeLock();
         writeLock.lock();
-        try (final BackupableDBOptions backupOptions = createBackupDBOptions(backupDBPath);
-             final BackupEngine backupEngine = BackupEngine.open(this.options.getEnv(), backupOptions)) {
+        try (final BackupableDBOptions backupOpts = createBackupDBOptions(backupDBPath);
+             final BackupEngine backupEngine = BackupEngine.open(this.options.getEnv(), backupOpts)) {
             backupEngine.createNewBackup(this.db, true);
             final List<BackupInfo> backupInfoList = backupEngine.getBackupInfo();
             if (backupInfoList.isEmpty()) {
@@ -1177,14 +1177,14 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
         final Lock writeLock = this.readWriteLock.writeLock();
         writeLock.lock();
         closeRocksDB();
-        try (final BackupableDBOptions options = createBackupDBOptions(backupDBPath);
-                final RestoreOptions restoreOptions = new RestoreOptions(false);
-                final BackupEngine backupEngine = BackupEngine.open(this.options.getEnv(), options)) {
+        try (final BackupableDBOptions backupOpts = createBackupDBOptions(backupDBPath);
+                final BackupEngine backupEngine = BackupEngine.open(this.options.getEnv(), backupOpts);
+                final RestoreOptions restoreOpts = new RestoreOptions(false)) {
             final ByteString userMeta = meta.getUserMeta();
             final RocksDBBackupInfo rocksBackupInfo = this.serializer.readObject(userMeta.toByteArray(),
                 RocksDBBackupInfo.class);
             final String dbPath = this.opts.getDbPath();
-            backupEngine.restoreDbFromBackup(rocksBackupInfo.getBackupId(), dbPath, dbPath, restoreOptions);
+            backupEngine.restoreDbFromBackup(rocksBackupInfo.getBackupId(), dbPath, dbPath, restoreOpts);
             LOG.info("Restored rocksDB from {} with {}.", backupDBPath, rocksBackupInfo);
             // reopen the db
             openRocksDB(this.opts);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -158,7 +158,8 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             this.writeOptions = new WriteOptions();
             this.writeOptions.setSync(opts.isSync());
             this.writeOptions.setDisableWAL(false);
-            // delete existing data because raft will play them back
+            // Delete existing data, relying on raft's snapshot and log playback
+            // to reply to the data is the correct behavior.
             FileUtils.deleteDirectory(new File(opts.getDbPath()));
             openRocksDB(opts);
             LOG.info("[RocksRawKVStore] start successfully, options: {}.", opts);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/RegionHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/RegionHelper.java
@@ -14,37 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.util;
+package com.alipay.sofa.jraft.rhea.util;
 
-import java.util.Locale;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
+import com.alipay.sofa.jraft.util.BytesUtil;
 
 /**
  *
  * @author jiachun.fjc
  */
-public class Platform {
+public final class RegionHelper {
 
-    private static final Logger  LOG        = LoggerFactory.getLogger(Platform.class);
-
-    private static final boolean IS_WINDOWS = isWindows0();
-
-    /**
-     * Return {@code true} if the JVM is running on Windows
-     */
-    public static boolean isWindows() {
-        return IS_WINDOWS;
+    public static boolean isSingleGroup(final Region region) {
+        return BytesUtil.nullToEmpty(region.getStartKey()).length == 0
+               && BytesUtil.nullToEmpty(region.getEndKey()).length == 0;
     }
 
-    private static boolean isWindows0() {
-        final boolean windows = SystemPropertyUtil.get("os.name", "") //
-            .toLowerCase(Locale.US) //
-            .contains("win");
-        if (windows) {
-            LOG.debug("Platform: Windows");
+    public static boolean isKeyInRegion(final byte[] key, final Region region) {
+        final byte[] startKey = BytesUtil.nullToEmpty(region.getStartKey());
+        if (BytesUtil.compare(key, startKey) < 0) {
+            return false;
         }
-        return windows;
+        final byte[] endKey = region.getEndKey();
+        return endKey == null || BytesUtil.compare(key, endKey) < 0;
+    }
+
+    private RegionHelper() {
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/RegionHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/RegionHelper.java
@@ -34,6 +34,13 @@ public final class RegionHelper {
         return !isSingleGroup(region);
     }
 
+    public static boolean isSameRange(final Region r1, final Region r2) {
+        if (BytesUtil.compare(BytesUtil.nullToEmpty(r1.getStartKey()), BytesUtil.nullToEmpty(r2.getStartKey())) != 0) {
+            return false;
+        }
+        return BytesUtil.compare(BytesUtil.nullToEmpty(r1.getEndKey()), BytesUtil.nullToEmpty(r2.getEndKey())) == 0;
+    }
+
     public static boolean isKeyInRegion(final byte[] key, final Region region) {
         final byte[] startKey = BytesUtil.nullToEmpty(region.getStartKey());
         if (BytesUtil.compare(key, startKey) < 0) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/RegionHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/RegionHelper.java
@@ -30,6 +30,10 @@ public final class RegionHelper {
                && BytesUtil.nullToEmpty(region.getEndKey()).length == 0;
     }
 
+    public static boolean isMultiGroup(final Region region) {
+        return !isSingleGroup(region);
+    }
+
     public static boolean isKeyInRegion(final byte[] key, final Region region) {
         final byte[] startKey = BytesUtil.nullToEmpty(region.getStartKey());
         if (BytesUtil.compare(key, startKey) < 0) {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/BaseRawStoreBenchmark.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/BaseRawStoreBenchmark.java
@@ -20,10 +20,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.rocksdb.HistogramData;
-import org.rocksdb.HistogramType;
-import org.rocksdb.StatisticsCollectorCallback;
-import org.rocksdb.TickerType;
 
 import com.alipay.sofa.jraft.rhea.options.RocksDBOptions;
 import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
@@ -42,23 +38,23 @@ public class BaseRawStoreBenchmark {
         this.dbOptions = new RocksDBOptions();
         this.dbOptions.setDbPath(this.tempPath);
         this.dbOptions.setSync(false);
-        this.dbOptions.setStatisticsCallbackIntervalSeconds(10);
+        //        this.dbOptions.setStatisticsCallbackIntervalSeconds(10);
         this.kvStore.init(this.dbOptions);
-        StatisticsCollectorCallback callback = new StatisticsCollectorCallback() {
-
-            @Override
-            public void tickerCallback(TickerType c, long tickerCount) {
-                System.out.print(c + " ");
-                System.out.println(tickerCount);
-            }
-
-            @Override
-            public void histogramCallback(HistogramType histType, HistogramData histData) {
-                System.out.print(histType + " ");
-                System.out.println(histData.getAverage());
-            }
-        };
-        this.kvStore.addStatisticsCollectorCallback(callback);
+        //        StatisticsCollectorCallback callback = new StatisticsCollectorCallback() {
+        //
+        //            @Override
+        //            public void tickerCallback(TickerType c, long tickerCount) {
+        //                System.out.print(c + " ");
+        //                System.out.println(tickerCount);
+        //            }
+        //
+        //            @Override
+        //            public void histogramCallback(HistogramType histType, HistogramData histData) {
+        //                System.out.print(histType + " ");
+        //                System.out.println(histData.getAverage());
+        //            }
+        //        };
+        //        this.kvStore.addStatisticsCollectorCallback(callback);
     }
 
     protected File getTempDir() throws IOException {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/BaseRawStoreBenchmark.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/BaseRawStoreBenchmark.java
@@ -38,23 +38,7 @@ public class BaseRawStoreBenchmark {
         this.dbOptions = new RocksDBOptions();
         this.dbOptions.setDbPath(this.tempPath);
         this.dbOptions.setSync(false);
-        //        this.dbOptions.setStatisticsCallbackIntervalSeconds(10);
         this.kvStore.init(this.dbOptions);
-        //        StatisticsCollectorCallback callback = new StatisticsCollectorCallback() {
-        //
-        //            @Override
-        //            public void tickerCallback(TickerType c, long tickerCount) {
-        //                System.out.print(c + " ");
-        //                System.out.println(tickerCount);
-        //            }
-        //
-        //            @Override
-        //            public void histogramCallback(HistogramType histType, HistogramData histData) {
-        //                System.out.print(histType + " ");
-        //                System.out.println(histData.getAverage());
-        //            }
-        //        };
-        //        this.kvStore.addStatisticsCollectorCallback(callback);
     }
 
     protected File getTempDir() throws IOException {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/SnapshotBenchmark.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/SnapshotBenchmark.java
@@ -26,6 +26,7 @@ import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
 
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.options.RocksDBOptions;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
@@ -189,12 +190,14 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
 
     private void doFastSnapshotSave(final String snapshotPath) throws Exception {
         this.dbOptions.setFastSnapshot(true);
-        this.kvStore.onSnapshotSave(snapshotPath);
+        final Region region = new Region();
+        this.kvStore.onSnapshotSave(snapshotPath, region);
     }
 
     private LocalFileMetaOutter.LocalFileMeta doSlowSnapshotSave(final String snapshotPath) throws Exception {
         this.dbOptions.setFastSnapshot(false);
-        return this.kvStore.onSnapshotSave(snapshotPath);
+        final Region region = new Region();
+        return this.kvStore.onSnapshotSave(snapshotPath, region);
     }
 
     private void doCompressSnapshot(final String path) {
@@ -211,7 +214,8 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
     private void doFastSnapshotLoad(final String snapshotPath) {
         try {
             this.dbOptions.setFastSnapshot(true);
-            this.kvStore.onSnapshotLoad(snapshotPath, null);
+            final Region region = new Region();
+            this.kvStore.onSnapshotLoad(snapshotPath, null, region);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -220,7 +224,8 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
     private void doSlowSnapshotLoad(final String snapshotPath, final LocalFileMetaOutter.LocalFileMeta meta) {
         try {
             this.dbOptions.setFastSnapshot(false);
-            this.kvStore.onSnapshotLoad(snapshotPath, meta);
+            final Region region = new Region();
+            this.kvStore.onSnapshotLoad(snapshotPath, meta, region);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/SnapshotBenchmark.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/SnapshotBenchmark.java
@@ -19,7 +19,12 @@ package com.alipay.sofa.jraft.rhea.benchmark.raw;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipOutputStream;
 
@@ -27,7 +32,6 @@ import org.apache.commons.io.FileUtils;
 
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter;
 import com.alipay.sofa.jraft.rhea.metadata.Region;
-import com.alipay.sofa.jraft.rhea.options.RocksDBOptions;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
 import com.alipay.sofa.jraft.rhea.util.Lists;
@@ -68,8 +72,8 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
 
     public void put() {
         final List<KVEntry> batch = Lists.newArrayListWithCapacity(100);
-        for (int i = 0; i < KEY_COUNT * 100; i++) {
-            byte[] key = BytesUtil.writeUtf8("benchmark_" + i);
+        for (int i = 0; i < KEY_COUNT * 10; i++) {
+            final byte[] key = BytesUtil.writeUtf8("benchmark_" + i);
             batch.add(new KVEntry(key, VALUE_BYTES));
             if (batch.size() >= 100) {
                 this.kvStore.put(batch, null);
@@ -78,92 +82,148 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
         }
     }
 
-    /*
-    100 million keys, the time unit is milliseconds
-
-     slow save snapshot time cost: 8265
-     slow compress time cost: 46517
-     slow load snapshot time cost: 21907
-
-     slow save snapshot time cost: 7424
-     slow compress time cost: 45040
-     slow load snapshot time cost: 19257
-
-     slow save snapshot time cost: 7025
-     slow compress time cost: 44410
-     slow load snapshot time cost: 20087
-
-     -----------------------------------------------------
-
-     fast save snapshot time cost: 742
-     fast compress time cost: 37548
-     fast load snapshot time cost: 13100
-
-     fast save snapshot time cost: 743
-     fast compress time cost: 43864
-     fast load snapshot time cost: 14176
-
-     fast save snapshot time cost: 755
-     fast compress time cost: 45789
-     fast load snapshot time cost: 14308
+    /**
+        -----------------------------------------------
+        db size = 10000000
+        slow save snapshot time cost: 2552
+        slow compressed file size: 41915298
+        slow compress time cost: 9173
+        slow load snapshot time cost: 5119
+        -----------------------------------------------
+        db size = 10000000
+        fast save snapshot time cost: 524
+        fast compressed file size: 41920248
+        fast compress time cost: 8807
+        fast load snapshot time cost: 3090
+        -----------------------------------------------
+        db size = 10000000
+        sst save snapshot time cost: 4296
+        sst compressed file size: 10741032
+        sst compress time cost: 2005
+        sst load snapshot time cost: 593
+        -----------------------------------------------
+        db size = 10000000
+        slow save snapshot time cost: 2248
+        slow compressed file size: 41918551
+        slow compress time cost: 8705
+        slow load snapshot time cost: 4485
+        -----------------------------------------------
+        db size = 10000000
+        fast save snapshot time cost: 508
+        fast compressed file size: 41914702
+        fast compress time cost: 8736
+        fast load snapshot time cost: 3047
+        -----------------------------------------------
+        db size = 10000000
+        sst save snapshot time cost: 4206
+        sst compressed file size: 10741032
+        sst compress time cost: 1950
+        sst load snapshot time cost: 599
+        -----------------------------------------------
+        db size = 10000000
+        slow save snapshot time cost: 2327
+        slow compressed file size: 41916640
+        slow compress time cost: 8643
+        slow load snapshot time cost: 4590
+        -----------------------------------------------
+        db size = 10000000
+        fast save snapshot time cost: 511
+        fast compressed file size: 41914533
+        fast compress time cost: 8704
+        fast load snapshot time cost: 3013
+        -----------------------------------------------
+        db size = 10000000
+        sst save snapshot time cost: 4253
+        sst compressed file size: 10741032
+        sst compress time cost: 1947
+        sst load snapshot time cost: 590
+        -----------------------------------------------
      */
 
     public static void main(String[] args) throws IOException {
         for (int i = 0; i < 3; i++) {
             SnapshotBenchmark snapshot = new SnapshotBenchmark();
             snapshot.setup();
-            snapshot.snapshot(false);
+            snapshot.snapshot(false, false);
             snapshot.tearDown();
-        }
 
-        for (int i = 0; i < 3; i++) {
-            SnapshotBenchmark snapshot = new SnapshotBenchmark();
+            snapshot = new SnapshotBenchmark();
             snapshot.setup();
-            snapshot.snapshot(true);
+            snapshot.snapshot(false, true);
+            snapshot.tearDown();
+
+            snapshot = new SnapshotBenchmark();
+            snapshot.setup();
+            snapshot.snapshot(true, true);
             snapshot.tearDown();
         }
     }
 
-    public void snapshot(boolean isFastSnapshot) throws IOException {
+    public void snapshot(final boolean isSstSnapshot, final boolean isFastSnapshot) throws IOException {
         final File backupDir = new File("backup");
         if (backupDir.exists()) {
             FileUtils.deleteDirectory(backupDir);
         }
         FileUtils.forceMkdir(backupDir);
 
-        final LocalFileMetaOutter.LocalFileMeta meta = doSnapshotSave(backupDir.getAbsolutePath(), isFastSnapshot);
+        final LocalFileMetaOutter.LocalFileMeta meta = doSnapshotSave(backupDir.getAbsolutePath(), isSstSnapshot,
+            isFastSnapshot);
 
         this.kvStore.shutdown();
         FileUtils.deleteDirectory(new File(this.tempPath));
         FileUtils.forceMkdir(new File(this.tempPath));
         this.kvStore = new RocksRawKVStore();
-        final RocksDBOptions dbOpts = new RocksDBOptions();
-        dbOpts.setDbPath(this.tempPath);
-        this.kvStore.init(dbOpts);
+        this.kvStore.init(this.dbOptions);
 
         final long loadStart = System.nanoTime();
         doSnapshotLoad(backupDir.getAbsolutePath(), meta, isFastSnapshot);
-        System.out.println((isFastSnapshot ? "fast" : "slow") + " load snapshot time cost: "
+        final String name;
+        if (isSstSnapshot) {
+            name = "sst";
+        } else {
+            if (isFastSnapshot) {
+                name = "fast";
+            } else {
+                name = "slow";
+            }
+        }
+        System.out.println(name + " load snapshot time cost: "
                            + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - loadStart));
         FileUtils.deleteDirectory(backupDir);
     }
 
-    private LocalFileMetaOutter.LocalFileMeta doSnapshotSave(final String path, final boolean isFastSnapshot) {
-        final String snapshotPath = path + File.separator + SNAPSHOT_DIR;
+    private LocalFileMetaOutter.LocalFileMeta doSnapshotSave(final String path, final boolean isSstSnapshot,
+                                                             final boolean isFastSnapshot) {
+        final String snapshotPath = Paths.get(path, SNAPSHOT_DIR).toString();
         try {
             final long saveStart = System.nanoTime();
-            final LocalFileMetaOutter.LocalFileMeta meta;
-            if (isFastSnapshot) {
-                doFastSnapshotSave(snapshotPath);
-                meta = null;
+            LocalFileMetaOutter.LocalFileMeta meta = null;
+            if (isSstSnapshot) {
+                doSstSnapshotSave(snapshotPath);
             } else {
-                meta = doSlowSnapshotSave(snapshotPath);
+                if (isFastSnapshot) {
+                    doFastSnapshotSave(snapshotPath);
+                } else {
+                    meta = doSlowSnapshotSave(snapshotPath);
+                }
             }
-            System.out.println((isFastSnapshot ? "fast" : "slow") + " save snapshot time cost: "
+            final String name;
+            if (isSstSnapshot) {
+                name = "sst";
+            } else {
+                if (isFastSnapshot) {
+                    name = "fast";
+                } else {
+                    name = "slow";
+                }
+            }
+            System.out.println(name + " save snapshot time cost: "
                                + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - saveStart));
             final long compressStart = System.nanoTime();
             doCompressSnapshot(path);
-            System.out.println((isFastSnapshot ? "fast" : "slow") + " compress time cost: "
+            System.out.println(name + " compressed file size: "
+                               + FileUtils.sizeOf(Paths.get(path, SNAPSHOT_ARCHIVE).toFile()));
+            System.out.println(name + " compress time cost: "
                                + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - compressStart));
             return meta;
         } catch (final Throwable t) {
@@ -174,12 +234,14 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
 
     public boolean doSnapshotLoad(final String path, final LocalFileMetaOutter.LocalFileMeta meta,
                                   final boolean isFastSnapshot) {
+        final String sourceFile = Paths.get(path, SNAPSHOT_ARCHIVE).toString();
+        final String snapshotPath = Paths.get(path, SNAPSHOT_DIR).toString();
         try {
-            ZipUtil.unzipFile(path + File.separator + SNAPSHOT_ARCHIVE, path);
+            ZipUtil.unzipFile(sourceFile, path);
             if (isFastSnapshot) {
-                doFastSnapshotLoad(path + File.separator + SNAPSHOT_DIR);
+                doFastSnapshotLoad(snapshotPath);
             } else {
-                doSlowSnapshotLoad(path + File.separator + SNAPSHOT_DIR, meta);
+                doSlowSnapshotLoad(snapshotPath, meta);
             }
             return true;
         } catch (final Throwable t) {
@@ -200,10 +262,44 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
         return this.kvStore.onSnapshotSave(snapshotPath, region);
     }
 
+    private void doSstSnapshotSave(final String snapshotPath) throws Exception {
+        FileUtils.forceMkdir(new File(snapshotPath));
+        final List<Region> regions = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            final Region r = new Region();
+            r.setId(i);
+            r.setStartKey(BytesUtil.writeUtf8("benchmark_" + i));
+            if (i < 9) {
+                r.setEndKey(BytesUtil.writeUtf8("benchmark_" + (i + 1)));
+            }
+            regions.add(r);
+        }
+        final ExecutorService executor = Executors.newFixedThreadPool(10);
+        final List<Future<?>> futures = Lists.newArrayList();
+        for (final Region r : regions) {
+            final Future<?> f = executor.submit(() -> {
+                try {
+                    this.kvStore.onSnapshotSave(Paths.get(snapshotPath, String.valueOf(r.getId())).toString(), r);
+                } catch (final Exception e) {
+                    e.printStackTrace();
+                }
+            });
+            futures.add(f);
+        }
+        for (final Future<?> f : futures) {
+            try {
+                f.get();
+            } catch (final InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
+        executor.shutdownNow();
+    }
+
     private void doCompressSnapshot(final String path) {
+        final String outputFile = Paths.get(path, SNAPSHOT_ARCHIVE).toString();
         try {
-            try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(path + File.separator
-                                                                                      + SNAPSHOT_ARCHIVE))) {
+            try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(outputFile))) {
                 ZipUtil.compressDirectoryToZipFile(path, SNAPSHOT_DIR, out);
             }
         } catch (final Throwable t) {
@@ -216,7 +312,7 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
             this.dbOptions.setFastSnapshot(true);
             final Region region = new Region();
             this.kvStore.onSnapshotLoad(snapshotPath, null, region);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             e.printStackTrace();
         }
     }
@@ -226,8 +322,41 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
             this.dbOptions.setFastSnapshot(false);
             final Region region = new Region();
             this.kvStore.onSnapshotLoad(snapshotPath, meta, region);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void doSstSnapshotLoad(final String snapshotPath) {
+        final List<Region> regions = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            final Region r = new Region();
+            r.setId(i);
+            r.setStartKey(BytesUtil.writeUtf8("benchmark_" + i));
+            if (i < 9) {
+                r.setEndKey(BytesUtil.writeUtf8("benchmark_" + (i + 1)));
+            }
+            regions.add(r);
+        }
+        final ExecutorService executor = Executors.newFixedThreadPool(10);
+        final List<Future<?>> futures = Lists.newArrayList();
+        for (final Region r : regions) {
+            final Future<?> f = executor.submit(() -> {
+                try {
+                    kvStore.onSnapshotLoad(Paths.get(snapshotPath, String.valueOf(r.getId())).toString(), null, r);
+                } catch (final Exception e) {
+                    e.printStackTrace();
+                }
+            });
+            futures.add(f);
+        }
+        for (final Future<?> f : futures) {
+            try {
+                f.get();
+            } catch (final InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
+        executor.shutdownNow();
     }
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/SnapshotBenchmark.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/benchmark/raw/SnapshotBenchmark.java
@@ -33,6 +33,7 @@ import org.apache.commons.io.FileUtils;
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter;
 import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
+import com.alipay.sofa.jraft.rhea.storage.KVStoreAccessHelper;
 import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
 import com.alipay.sofa.jraft.rhea.util.Lists;
 import com.alipay.sofa.jraft.rhea.util.ZipUtil;
@@ -253,13 +254,13 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
     private void doFastSnapshotSave(final String snapshotPath) throws Exception {
         this.dbOptions.setFastSnapshot(true);
         final Region region = new Region();
-        this.kvStore.onSnapshotSave(snapshotPath, region);
+        KVStoreAccessHelper.saveSnapshot(this.kvStore, snapshotPath, region);
     }
 
     private LocalFileMetaOutter.LocalFileMeta doSlowSnapshotSave(final String snapshotPath) throws Exception {
         this.dbOptions.setFastSnapshot(false);
         final Region region = new Region();
-        return this.kvStore.onSnapshotSave(snapshotPath, region);
+        return KVStoreAccessHelper.saveSnapshot(this.kvStore, snapshotPath, region);
     }
 
     private void doSstSnapshotSave(final String snapshotPath) throws Exception {
@@ -279,7 +280,7 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
         for (final Region r : regions) {
             final Future<?> f = executor.submit(() -> {
                 try {
-                    this.kvStore.onSnapshotSave(Paths.get(snapshotPath, String.valueOf(r.getId())).toString(), r);
+                    KVStoreAccessHelper.saveSnapshot(this.kvStore, Paths.get(snapshotPath, String.valueOf(r.getId())).toString(), r);
                 } catch (final Exception e) {
                     e.printStackTrace();
                 }
@@ -311,7 +312,7 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
         try {
             this.dbOptions.setFastSnapshot(true);
             final Region region = new Region();
-            this.kvStore.onSnapshotLoad(snapshotPath, null, region);
+            KVStoreAccessHelper.loadSnapshot(this.kvStore, snapshotPath, null, region);
         } catch (final Exception e) {
             e.printStackTrace();
         }
@@ -321,7 +322,7 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
         try {
             this.dbOptions.setFastSnapshot(false);
             final Region region = new Region();
-            this.kvStore.onSnapshotLoad(snapshotPath, meta, region);
+            KVStoreAccessHelper.loadSnapshot(this.kvStore, snapshotPath, meta, region);
         } catch (final Exception e) {
             e.printStackTrace();
         }
@@ -343,7 +344,7 @@ public class SnapshotBenchmark extends BaseRawStoreBenchmark {
         for (final Region r : regions) {
             final Future<?> f = executor.submit(() -> {
                 try {
-                    kvStore.onSnapshotLoad(Paths.get(snapshotPath, String.valueOf(r.getId())).toString(), null, r);
+                    KVStoreAccessHelper.loadSnapshot(kvStore, Paths.get(snapshotPath, String.valueOf(r.getId())).toString(), null, r);
                 } catch (final Exception e) {
                     e.printStackTrace();
                 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/KVStoreAccessHelper.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/KVStoreAccessHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage;
+
+import java.io.File;
+import java.util.EnumMap;
+
+import com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
+import com.alipay.sofa.jraft.rhea.metadata.Region;
+
+/**
+ * KV store test helper
+ *
+ * @author jiachun.fjc
+ */
+public final class KVStoreAccessHelper {
+
+    public static void createSstFiles(final RocksRawKVStore store, final EnumMap<SstColumnFamily, File> sstFileTable,
+                                      final byte[] startKey, final byte[] endKey) {
+        store.createSstFiles(sstFileTable, startKey, endKey);
+    }
+
+    public static void ingestSstFiles(final RocksRawKVStore store, final EnumMap<SstColumnFamily, File> sstFileTable) {
+        store.ingestSstFiles(sstFileTable);
+    }
+
+    public static LocalFileMeta saveSnapshot(final BaseRawKVStore<?> store, final String snapshotPath,
+                                             final Region region) throws Exception {
+        final KVStoreSnapshotFile snapshotFile = KVStoreSnapshotFileFactory.getKVStoreSnapshotFile(store);
+        return ((AbstractKVStoreSnapshotFile) snapshotFile).doSnapshotSave(snapshotPath, region);
+    }
+
+    public static void loadSnapshot(final BaseRawKVStore<?> store, final String snapshotPath, final LocalFileMeta meta,
+                                    final Region region) throws Exception {
+        final KVStoreSnapshotFile snapshotFile = KVStoreSnapshotFileFactory.getKVStoreSnapshotFile(store);
+        ((AbstractKVStoreSnapshotFile) snapshotFile).doSnapshotLoad(snapshotPath, meta, region);
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/LocalLock.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/LocalLock.java
@@ -47,7 +47,7 @@ public class LocalLock extends DistributedLock<byte[]> {
         final Acquirer acquirer = getAcquirer();
         acquirer.setContext(ctx);
         final KVStoreClosure closure = new TestClosure();
-        this.rawKVStore.tryLockWith(internalKey, false, acquirer, closure);
+        this.rawKVStore.tryLockWith(internalKey, internalKey, false, acquirer, closure);
         final Owner owner = (Owner) closure.getData();
         updateOwnerAndAcquirer(owner);
         return owner;

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -18,6 +18,8 @@ package com.alipay.sofa.jraft.rhea.storage.memorydb;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.options.MemoryDBOptions;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.storage.KVIterator;
@@ -104,7 +107,6 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     /**
      * Test method: {@link MemoryRawKVStore#multiGet(List, KVStoreClosure)}
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void multiGetTest() {
         final List<byte[]> keyList = Lists.newArrayList();
@@ -234,7 +236,6 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     /**
      * Test method: {@link MemoryRawKVStore#scan(byte[], byte[], KVStoreClosure)}
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void scanTest() {
         final List<byte[]> keyList = Lists.newArrayList();
@@ -356,7 +357,6 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     /**
      * Test method: {@link MemoryRawKVStore#put(List, KVStoreClosure)}
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void putListTest() {
         final List<KVEntry> entries = Lists.newArrayList();
@@ -488,8 +488,11 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
             final String v = String.valueOf(i);
             this.kvStore.put(makeKey(v), makeValue(v), null);
         }
-
-        final LocalFileMeta meta = doSnapshotSave(backupDir.getAbsolutePath());
+        for (int i = 0; i < 10000; i++) {
+            this.kvStore.getSequence(makeKey((i % 100) + "seq_test"), 10, null);
+        }
+        final Region region = new Region();
+        final LocalFileMeta meta = doSnapshotSave(backupDir.getAbsolutePath(), region);
 
         assertNotNull(get(makeKey("1")));
 
@@ -503,7 +506,7 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
 
         assertNull(get(makeKey("1")));
 
-        doSnapshotLoad(backupDir.getAbsolutePath(), meta);
+        doSnapshotLoad(backupDir.getAbsolutePath(), meta, region);
 
         for (int i = 0; i < 100000; i++) {
             final String v = String.valueOf(i);
@@ -516,10 +519,75 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
         FileUtils.deleteDirectory(backupDir);
     }
 
-    private LocalFileMeta doSnapshotSave(final String path) {
+    @Test
+    public void multiGroupSnapshotTest() throws Exception {
+        final File backupDir = new File("multi-backup");
+        if (backupDir.exists()) {
+            FileUtils.deleteDirectory(backupDir);
+        }
+
+        final List<Region> regions = Lists.newArrayList();
+        final List<LocalFileMeta> metas = Lists.newArrayList();
+        regions.add(new Region(1, makeKey("0"), makeKey("1"), null, null));
+        regions.add(new Region(2, makeKey("1"), makeKey("2"), null, null));
+        regions.add(new Region(3, makeKey("2"), makeKey("3"), null, null));
+        regions.add(new Region(4, makeKey("3"), makeKey("4"), null, null));
+        regions.add(new Region(5, makeKey("4"), makeKey("5"), null, null));
+
+        for (int i = 0; i < 5; i++) {
+            final String v = String.valueOf(i);
+            this.kvStore.put(makeKey(v), makeValue(v), null);
+        }
+        for (int i = 0; i < 5; i++) {
+            this.kvStore.getSequence(makeKey(i + "_seq_test"), 10, null);
+        }
+
+        for (int i = 0; i < 4; i++) {
+            final Path p = Paths.get(backupDir.getAbsolutePath(), String.valueOf(i));
+            final LocalFileMeta meta = doSnapshotSave(p.toString(), regions.get(i));
+            metas.add(meta);
+        }
+
+        this.kvStore.shutdown();
+        this.kvStore = new MemoryRawKVStore();
+        final MemoryDBOptions dbOpts = new MemoryDBOptions();
+        this.kvStore.init(dbOpts);
+
+        for (int i = 0; i < 4; i++) {
+            final Path p = Paths.get(backupDir.getAbsolutePath(), String.valueOf(i));
+            doSnapshotLoad(p.toString(), metas.get(i), regions.get(i));
+        }
+
+        for (int i = 0; i < 4; i++) {
+            final String v = String.valueOf(i);
+            final byte[] seqKey = makeKey(i + "_seq_test");
+            assertArrayEquals(makeValue(v), get(makeKey(v)));
+            final Sequence sequence = new SyncKVStore<Sequence>() {
+                @Override
+                public void execute(RawKVStore kvStore, KVStoreClosure closure) {
+                    kvStore.getSequence(seqKey, 10, closure);
+                }
+            }.apply(this.kvStore);
+            assertEquals(10L, sequence.getStartValue());
+            assertEquals(20L, sequence.getEndValue());
+        }
+
+        assertNull(get(makeKey("5")));
+        final Sequence sequence = new SyncKVStore<Sequence>() {
+            @Override
+            public void execute(RawKVStore kvStore, KVStoreClosure closure) {
+                kvStore.getSequence(makeKey("4_seq_test"), 10, closure);
+            }
+        }.apply(this.kvStore);
+        assertEquals(0L, sequence.getStartValue());
+
+        FileUtils.deleteDirectory(backupDir);
+    }
+
+    private LocalFileMeta doSnapshotSave(final String path, final Region region) {
         final String snapshotPath = path + File.separator + SNAPSHOT_DIR;
         try {
-            final LocalFileMeta meta = this.kvStore.onSnapshotSave(snapshotPath);
+            final LocalFileMeta meta = this.kvStore.onSnapshotSave(snapshotPath, region);
             doCompressSnapshot(path);
             return meta;
         } catch (final Throwable t) {
@@ -528,10 +596,10 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
         return null;
     }
 
-    public boolean doSnapshotLoad(final String path, final LocalFileMeta meta) {
+    public boolean doSnapshotLoad(final String path, final LocalFileMeta meta, final Region region) {
         try {
             ZipUtil.unzipFile(path + File.separator + SNAPSHOT_ARCHIVE, path);
-            this.kvStore.onSnapshotLoad(path + File.separator + SNAPSHOT_DIR, meta);
+            this.kvStore.onSnapshotLoad(path + File.separator + SNAPSHOT_DIR, meta, region);
             return true;
         } catch (final Throwable t) {
             t.printStackTrace();

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -36,6 +36,7 @@ import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.options.MemoryDBOptions;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.storage.KVIterator;
+import com.alipay.sofa.jraft.rhea.storage.KVStoreAccessHelper;
 import com.alipay.sofa.jraft.rhea.storage.KVStoreClosure;
 import com.alipay.sofa.jraft.rhea.storage.LocalLock;
 import com.alipay.sofa.jraft.rhea.storage.MemoryRawKVStore;
@@ -588,7 +589,7 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     private LocalFileMeta doSnapshotSave(final String path, final Region region) {
         final String snapshotPath = Paths.get(path, SNAPSHOT_DIR).toString();
         try {
-            final LocalFileMeta meta = this.kvStore.onSnapshotSave(snapshotPath, region);
+            final LocalFileMeta meta = KVStoreAccessHelper.saveSnapshot(this.kvStore, snapshotPath, region);
             doCompressSnapshot(path);
             return meta;
         } catch (final Throwable t) {
@@ -602,7 +603,7 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
         final String snapshotPath = Paths.get(path, SNAPSHOT_DIR).toString();
         try {
             ZipUtil.unzipFile(sourceFile, path);
-            this.kvStore.onSnapshotLoad(snapshotPath, meta, region);
+            KVStoreAccessHelper.loadSnapshot(this.kvStore, snapshotPath, meta, region);
             return true;
         } catch (final Throwable t) {
             t.printStackTrace();

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -585,7 +585,7 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     }
 
     private LocalFileMeta doSnapshotSave(final String path, final Region region) {
-        final String snapshotPath = path + File.separator + SNAPSHOT_DIR;
+        final String snapshotPath = Paths.get(path, SNAPSHOT_DIR).toString();
         try {
             final LocalFileMeta meta = this.kvStore.onSnapshotSave(snapshotPath, region);
             doCompressSnapshot(path);
@@ -597,9 +597,11 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     }
 
     public boolean doSnapshotLoad(final String path, final LocalFileMeta meta, final Region region) {
+        final String sourceFile = Paths.get(path, SNAPSHOT_ARCHIVE).toString();
+        final String snapshotPath = Paths.get(path, SNAPSHOT_DIR).toString();
         try {
-            ZipUtil.unzipFile(path + File.separator + SNAPSHOT_ARCHIVE, path);
-            this.kvStore.onSnapshotLoad(path + File.separator + SNAPSHOT_DIR, meta, region);
+            ZipUtil.unzipFile(sourceFile, path);
+            this.kvStore.onSnapshotLoad(snapshotPath, meta, region);
             return true;
         } catch (final Throwable t) {
             t.printStackTrace();
@@ -608,9 +610,9 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     }
 
     private void doCompressSnapshot(final String path) {
+        final String outputFile = Paths.get(path, SNAPSHOT_ARCHIVE).toString();
         try {
-            try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(path + File.separator
-                                                                                      + SNAPSHOT_ARCHIVE))) {
+            try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(outputFile))) {
                 ZipUtil.compressDirectoryToZipFile(path, SNAPSHOT_DIR, out);
             }
         } catch (final Throwable t) {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.jraft.rhea.storage.memorydb;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -392,7 +393,7 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     }
 
     /**
-     * Test method: {@link MemoryRawKVStore#tryLockWith(byte[], boolean, DistributedLock.Acquirer, KVStoreClosure)}
+     * Test method: {@link MemoryRawKVStore#tryLockWith(byte[], byte[], boolean, DistributedLock.Acquirer, KVStoreClosure)}
      */
     @Test
     public void tryLockWith() throws InterruptedException {
@@ -647,5 +648,24 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
         final byte[] endKey = this.kvStore.jumpOver(makeKey("approximate_test0000"), 1000);
         final long approximateKeys = this.kvStore.getApproximateKeysInRange(makeKey("approximate_test0000"), endKey);
         assertEquals(1000, approximateKeys, 10);
+    }
+
+    @Test
+    public void initFencingTokenTest() throws Exception {
+        final Method getNextFencingMethod = MemoryRawKVStore.class.getDeclaredMethod("getNextFencingToken",
+            byte[].class);
+        getNextFencingMethod.setAccessible(true);
+        final List<byte[]> parentKeys = Lists.newArrayList();
+        parentKeys.add(null); // startKey == null
+        parentKeys.add(BytesUtil.writeUtf8("parent"));
+        for (int i = 0; i < 2; i++) {
+            final byte[] parentKey = parentKeys.get(i);
+            final byte[] childKey = BytesUtil.writeUtf8("child");
+            assertEquals(1L, getNextFencingMethod.invoke(this.kvStore, (Object) parentKey));
+            assertEquals(2L, getNextFencingMethod.invoke(this.kvStore, (Object) parentKey));
+            this.kvStore.initFencingToken(parentKey, childKey);
+            assertEquals(3L, getNextFencingMethod.invoke(this.kvStore, (Object) childKey));
+            assertEquals(4L, getNextFencingMethod.invoke(this.kvStore, (Object) childKey));
+        }
     }
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.jraft.rhea.storage.rhea;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -731,9 +730,7 @@ public abstract class AbstractRheaKVStoreTest extends RheaKVTestCluster {
 
         store.shutdown();
 
-        final Field optsField = store.getClass().getDeclaredField("opts");
-        optsField.setAccessible(true);
-        final RheaKVStoreOptions opts = (RheaKVStoreOptions) optsField.get(store);
+        final RheaKVStoreOptions opts = super.optsMapping.get(store);
 
         store.init(opts);
 


### PR DESCRIPTION
背景：

https://github.com/alipay/sofa-jraft/issues/37

rheaKV 是 multi-raft-group 设计，但是 kv 存储是共享的，原来做 snapshot 是当前节点（Store）全量数据 snapshot，这有几个问题：

1. 多分重复数据，本地存储浪费，install snapshot 时快照网络传输也是很大开销 
2. 每个 region 都会定时触发 snapshot，都是全量数据，snapshot 期间还是禁写禁读的，一个 region 做 snapshot 可能导致整个节点一段时间内无法提供服务

改进方案是：

1.  对于 RocksRawKVStore，采用 [sst file](https://github.com/facebook/rocksdb/wiki/Creating-and-Ingesting-SST-files) 的方式, 对一个 region 的 key range 生成 sst file， snapshot load 是直接 ingest sst file 即可
2. 对于 MemoryRawKVStore，因为是跳表结构存储，很容易根据一个 key range subMap 出当前 region 包含数据即可

改进以后的好处是：

1. **最大的好处就是 一个 region 在做 snapshot 期间，整个 kv 依旧可以对其他 region 提供并发读写**
2. 每个 region 只 snapshot 自己的数据，磁盘，网络都得到节省
3. 所有 region 的 snapshot 加起来的大小只有原来的 1/4， 压缩时间自然也就缩短了，只测了全部 region 一起压缩，没有测试单个 region snapshot 的压缩时间，实际程序运行中是单个 region 压缩的，会更快
4. snapshot file 文件变小（ 算所有region 总量仍然比 rocksdb backup 小很多）
5. load snapshot 飞快

缺点：
生成 sst file 不是很快，需要控制一个 region 的大小，简单测试了下对于 100 个字节的 value，最好一个 region 的 key 数量不要超过千万量级

以下为一千万个 key 的 snapshot 压测数据，其中 sst 前缀的为新的 snapshot 实现，测试代码见 SnapshotBenchmark：

        -----------------------------------------------
        db size = 10000000
        slow save snapshot time cost: 2552
        slow compressed file size: 41915298
        slow compress time cost: 9173
        slow load snapshot time cost: 5119
        -----------------------------------------------
        db size = 10000000
        sst save snapshot time cost: 4296
        sst compressed file size: 10741032
        sst compress time cost: 2005
        sst load snapshot time cost: 593
        -----------------------------------------------
        db size = 10000000
        slow save snapshot time cost: 2248
        slow compressed file size: 41918551
        slow compress time cost: 8705
        slow load snapshot time cost: 4485
        -----------------------------------------------
        db size = 10000000
        sst save snapshot time cost: 4206
        sst compressed file size: 10741032
        sst compress time cost: 1950
        sst load snapshot time cost: 599
        -----------------------------------------------
        db size = 10000000
        slow save snapshot time cost: 2327
        slow compressed file size: 41916640
        slow compress time cost: 8643
        slow load snapshot time cost: 4590

        -----------------------------------------------
        db size = 10000000
        sst save snapshot time cost: 4253
        sst compressed file size: 10741032
        sst compress time cost: 1947
        sst load snapshot time cost: 590
        -----------------------------------------------