### PR TITLE
(fix) optimize 'delete range with memory db'

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
@@ -576,8 +576,8 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
         final Timer.Context timeCtx = getTimeContext("DELETE_RANGE");
         try {
             final ConcurrentNavigableMap<byte[], byte[]> subMap = this.defaultDB.subMap(startKey, endKey);
-            for (final byte[] key : subMap.keySet()) {
-                this.defaultDB.remove(key);
+            if (!subMap.isEmpty()) {
+                subMap.clear();
             }
             setSuccess(closure, Boolean.TRUE);
         } catch (final Exception e) {


### PR DESCRIPTION
use subMap.clear() instead of foreach to delete