### PR TITLE
(fix) Impl moving file atomically on windows, #54

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/ProtoBufFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/ProtoBufFile.java
@@ -58,7 +58,7 @@ public class ProtoBufFile {
     /** file path */
     private final String        path;
 
-    public ProtoBufFile(String path) {
+    public ProtoBufFile(final String path) {
         this.path = path;
     }
 
@@ -90,7 +90,7 @@ public class ProtoBufFile {
         }
     }
 
-    private void readBytes(byte[] bs, InputStream input) throws IOException {
+    private void readBytes(final byte[] bs, final InputStream input) throws IOException {
         int read;
         if ((read = input.read(bs)) != bs.length) {
             throw new IOException("Read error, expects " + bs.length + " bytes, but read " + read);
@@ -104,7 +104,7 @@ public class ProtoBufFile {
      * @param sync  if sync flush data to disk
      * @return      true if save success
      */
-    public boolean save(Message msg, boolean sync) throws IOException {
+    public boolean save(final Message msg, final boolean sync) throws IOException {
         // Write message into temp file
         File file = new File(this.path + ".tmp");
         try (FileOutputStream fOut = new FileOutputStream(file);
@@ -133,7 +133,7 @@ public class ProtoBufFile {
         File destFile = new File(this.path);
         Path destPath = destFile.toPath();
         try {
-            return Files.move(tmpPath, destPath, StandardCopyOption.ATOMIC_MOVE) == destPath;
+            return Files.move(tmpPath, destPath, StandardCopyOption.ATOMIC_MOVE) != null;
         } catch (final IOException e) {
             // If it falls here that can mean many things. Either that the atomic move is not supported,
             // or something wrong happened. Anyway, let's try to be over-diagnosing
@@ -148,7 +148,7 @@ public class ProtoBufFile {
             }
 
             try {
-                return Files.move(tmpPath, destPath, StandardCopyOption.REPLACE_EXISTING) == destPath;
+                return Files.move(tmpPath, destPath, StandardCopyOption.REPLACE_EXISTING) != null;
             } catch (final IOException e1) {
                 e1.addSuppressed(e);
                 LOG.warn("Unable to move {} to {}. Attempting to delete {} and abandoning.", tmpPath, destPath, tmpPath);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/ProtoBufFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/ProtoBufFile.java
@@ -134,7 +134,7 @@ public class ProtoBufFile {
         Path destPath = destFile.toPath();
         try {
             return Files.move(tmpPath, destPath, StandardCopyOption.ATOMIC_MOVE) == destPath;
-        } catch (IOException e) {
+        } catch (final IOException e) {
             // If it falls here that can mean many things. Either that the atomic move is not supported,
             // or something wrong happened. Anyway, let's try to be over-diagnosing
             if (e instanceof AtomicMoveNotSupportedException) {
@@ -144,12 +144,12 @@ public class ProtoBufFile {
             }
 
             if (destFile.exists()) {
-                LOG.info("The target file { } was already existing", destPath);
+                LOG.info("The target file {} was already existing.", destPath);
             }
 
             try {
                 return Files.move(tmpPath, destPath, StandardCopyOption.REPLACE_EXISTING) == destPath;
-            } catch (IOException e1) {
+            } catch (final IOException e1) {
                 e1.addSuppressed(e);
                 LOG.warn("Unable to move {} to {}. Attempting to delete {} and abandoning.", tmpPath, destPath, tmpPath);
                 try {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/ProtoBufFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/ProtoBufFile.java
@@ -23,6 +23,13 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.alipay.sofa.jraft.rpc.ProtobufMsgFactory;
 import com.alipay.sofa.jraft.util.Bits;
@@ -42,12 +49,14 @@ import com.google.protobuf.Message;
  */
 public class ProtoBufFile {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ProtoBufFile.class);
+
     static {
         ProtobufMsgFactory.load();
     }
 
     /** file path */
-    private final String path;
+    private final String        path;
 
     public ProtoBufFile(String path) {
         this.path = path;
@@ -96,6 +105,7 @@ public class ProtoBufFile {
      * @return      true if save success
      */
     public boolean save(Message msg, boolean sync) throws IOException {
+        // Write message into temp file
         File file = new File(this.path + ".tmp");
         try (FileOutputStream fOut = new FileOutputStream(file);
                 BufferedOutputStream output = new BufferedOutputStream(fOut)) {
@@ -117,6 +127,41 @@ public class ProtoBufFile {
             }
         }
 
-        return file.renameTo(new File(path));
+        // Move temp file to target path atomically.
+        // The code comes from https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/AtomicFileWriter.java#L187
+        Path tmpPath = file.toPath();
+        File destFile = new File(this.path);
+        Path destPath = destFile.toPath();
+        try {
+            return Files.move(tmpPath, destPath, StandardCopyOption.ATOMIC_MOVE) == destPath;
+        } catch (IOException e) {
+            // If it falls here that can mean many things. Either that the atomic move is not supported,
+            // or something wrong happened. Anyway, let's try to be over-diagnosing
+            if (e instanceof AtomicMoveNotSupportedException) {
+                LOG.warn("Atomic move not supported. falling back to non-atomic move, error: {}.", e.getMessage());
+            } else {
+                LOG.warn("Unable to move atomically, falling back to non-atomic move, error: {}.", e.getMessage());
+            }
+
+            if (destFile.exists()) {
+                LOG.info("The target file { } was already existing", destPath);
+            }
+
+            try {
+                return Files.move(tmpPath, destPath, StandardCopyOption.REPLACE_EXISTING) == destPath;
+            } catch (IOException e1) {
+                e1.addSuppressed(e);
+                LOG.warn("Unable to move {} to {}. Attempting to delete {} and abandoning.", tmpPath, destPath, tmpPath);
+                try {
+                    Files.deleteIfExists(tmpPath);
+                } catch (IOException e2) {
+                    e2.addSuppressed(e1);
+                    LOG.warn("Unable to delete {}, good bye then!", tmpPath);
+                    throw e2;
+                }
+
+                throw e1;
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation:

Use `Files.move(source,path,opts)` to replace `File#renameTo(file)` for moving files atomically.

The code is from 

https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/AtomicFileWriter.java#L187

### Modification:

Modify the `ProtoBufFile#save()` implementation.

### Result:

Fixes #54 


