### PR TITLE
(fix) chaos test was ignored by mvn test

### DIFF
--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryDBBatchingTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryDBBatchingTest.java
@@ -22,16 +22,16 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosMemory extends AbstractChaosTest {
+public class ChaosMemoryDBBatchingTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {
-        return StorageType.RocksDB;
+        return StorageType.Memory;
     }
 
     @Override
     public boolean isAllowBatching() {
-        return false;
+        return true;
     }
 
     @Override

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryDBLeaderReadBatchingTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryDBLeaderReadBatchingTest.java
@@ -22,20 +22,20 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosRocksDB extends AbstractChaosTest {
+public class ChaosMemoryDBLeaderReadBatchingTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {
-        return StorageType.RocksDB;
+        return StorageType.Memory;
     }
 
     @Override
     public boolean isAllowBatching() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isOnlyLeaderRead() {
-        return false;
+        return true;
     }
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryLeaderReadTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryLeaderReadTest.java
@@ -22,7 +22,7 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosRocksDBBatching extends AbstractChaosTest {
+public class ChaosMemoryLeaderReadTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {
@@ -31,11 +31,11 @@ public class ChaosRocksDBBatching extends AbstractChaosTest {
 
     @Override
     public boolean isAllowBatching() {
-        return true;
+        return false;
     }
 
     @Override
     public boolean isOnlyLeaderRead() {
-        return false;
+        return true;
     }
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosMemoryTest.java
@@ -22,7 +22,7 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosMemoryLeaderRead extends AbstractChaosTest {
+public class ChaosMemoryTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {
@@ -36,6 +36,6 @@ public class ChaosMemoryLeaderRead extends AbstractChaosTest {
 
     @Override
     public boolean isOnlyLeaderRead() {
-        return true;
+        return false;
     }
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBBatchingTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBBatchingTest.java
@@ -22,7 +22,7 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosRocksDBLeaderReadBatching extends AbstractChaosTest {
+public class ChaosRocksDBBatchingTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {
@@ -36,6 +36,6 @@ public class ChaosRocksDBLeaderReadBatching extends AbstractChaosTest {
 
     @Override
     public boolean isOnlyLeaderRead() {
-        return true;
+        return false;
     }
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBLeaderReadBatchingTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBLeaderReadBatchingTest.java
@@ -22,11 +22,11 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosMemoryDBBatching extends AbstractChaosTest {
+public class ChaosRocksDBLeaderReadBatchingTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {
-        return StorageType.Memory;
+        return StorageType.RocksDB;
     }
 
     @Override
@@ -36,6 +36,6 @@ public class ChaosMemoryDBBatching extends AbstractChaosTest {
 
     @Override
     public boolean isOnlyLeaderRead() {
-        return false;
+        return true;
     }
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBLeaderReadTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBLeaderReadTest.java
@@ -22,7 +22,7 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosRocksDBLeaderRead extends AbstractChaosTest {
+public class ChaosRocksDBLeaderReadTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosRocksDBTest.java
@@ -22,20 +22,20 @@ import com.alipay.sofa.jraft.rhea.storage.StorageType;
  *
  * @author jiachun.fjc
  */
-public class ChaosMemoryDBLeaderReadBatching extends AbstractChaosTest {
+public class ChaosRocksDBTest extends AbstractChaosTest {
 
     @Override
     public StorageType getStorageType() {
-        return StorageType.Memory;
+        return StorageType.RocksDB;
     }
 
     @Override
     public boolean isAllowBatching() {
-        return true;
+        return false;
     }
 
     @Override
     public boolean isOnlyLeaderRead() {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
### Motivation:

chaos test was ignored by mvn test

### Modification:

Rename the test class name， let it match with maven-surefire-plugin’s includes setting

### Result:

No longer be ignored，so happy！
