### PR TITLE
(fix) remove statistics collector on unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 jdk:
   - openjdk8
-  - openjdk11
 
 env:
   - TESTFOLDER=jraft-core

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/BaseKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/BaseKVStoreTest.java
@@ -20,10 +20,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.rocksdb.HistogramData;
-import org.rocksdb.HistogramType;
-import org.rocksdb.StatisticsCollectorCallback;
-import org.rocksdb.TickerType;
 
 import com.alipay.sofa.jraft.rhea.options.RocksDBOptions;
 import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
@@ -42,21 +38,6 @@ public class BaseKVStoreTest {
         this.dbOptions.setStatisticsCallbackIntervalSeconds(10);
         this.dbOptions.setDbPath(this.tempPath);
         this.kvStore.init(this.dbOptions);
-        StatisticsCollectorCallback callback = new StatisticsCollectorCallback() {
-
-            @Override
-            public void tickerCallback(TickerType c, long tickerCount) {
-                System.out.print(c + " ");
-                System.out.println(tickerCount);
-            }
-
-            @Override
-            public void histogramCallback(HistogramType histType, HistogramData histData) {
-                System.out.print(histType + " ");
-                System.out.println(histData.getAverage());
-            }
-        };
-        this.kvStore.addStatisticsCollectorCallback(callback);
     }
 
     protected File getTempDir() throws IOException {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
@@ -37,14 +37,13 @@ import org.junit.Test;
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
 import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.options.RocksDBOptions;
-import com.alipay.sofa.jraft.rhea.rocks.support.RocksStatistics;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.storage.KVIterator;
+import com.alipay.sofa.jraft.rhea.storage.KVStoreAccessHelper;
 import com.alipay.sofa.jraft.rhea.storage.KVStoreClosure;
 import com.alipay.sofa.jraft.rhea.storage.LocalLock;
 import com.alipay.sofa.jraft.rhea.storage.RawKVStore;
 import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
-import com.alipay.sofa.jraft.rhea.storage.KVStoreAccessHelper;
 import com.alipay.sofa.jraft.rhea.storage.Sequence;
 import com.alipay.sofa.jraft.rhea.storage.SstColumnFamily;
 import com.alipay.sofa.jraft.rhea.storage.SyncKVStore;
@@ -82,7 +81,6 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
     @Override
     @After
     public void tearDown() throws Exception {
-        System.out.println(RocksStatistics.getStatisticsString(this.kvStore));
         super.tearDown();
     }
 


### PR DESCRIPTION
### Motivation:

Too much log at unit test

### Modification:

Remove statistics collector

### Result:

