### PR TITLE
Bugfix/readindex concurrent bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 jdk:
   - openjdk8
-  - openjdk11
 
 env:
   - TESTFOLDER=jraft-core


### PR DESCRIPTION
### Motivation:

See #120 

### Modification:

Use `ReadIndexState` when call `notifyFail` method

### Result:

Fixes #120 

