### PR TITLE
(fix) fix travis build failed with openjdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 jdk:
   - openjdk8
-  - openjdk11
 
 env:
   - TESTFOLDER=jraft-core


### PR DESCRIPTION
### Motivation:

travis build failed with openjdk11 （casue：Couldn't determine a download url for 11-GPL on linux-x64）

### Modification:

remove openjdk11

### Result:


