### PR TITLE
Feat/optimize encode

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1680,7 +1680,7 @@ public class NodeImpl implements Node, RaftServerService {
                     if (this.raftOptions.isEnableLogEntryChecksum() && logEntry.isCorrupted()) {
                         long realChecksum = logEntry.checksum();
                         LOG.error(
-                            "Corrupted log entry received from leader, index={}, term={}, expectecChecksum={}, realChecksum={}",
+                            "Corrupted log entry received from leader, index={}, term={}, expectedChecksum={}, realChecksum={}",
                             logEntry.getId().getIndex(), logEntry.getId().getTerm(), logEntry.getChecksum(),
                             realChecksum);
                         return RpcResponseFactory.newResponse(RaftError.EINVAL,

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/LogEntryV2CodecFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/LogEntryV2CodecFactory.java
@@ -35,13 +35,9 @@ import com.alipay.sofa.jraft.entity.codec.LogEntryEncoder;
  */
 public class LogEntryV2CodecFactory implements LogEntryCodecFactory {
 
-    private LogEntryV2CodecFactory() {
-
-    }
-
     private static final LogEntryV2CodecFactory INSTANCE = new LogEntryV2CodecFactory();
 
-    public static final LogEntryV2CodecFactory getInstance() {
+    public static LogEntryV2CodecFactory getInstance() {
         return INSTANCE;
     }
 
@@ -64,4 +60,6 @@ public class LogEntryV2CodecFactory implements LogEntryCodecFactory {
         return AutoDetectDecoder.INSTANCE;
     }
 
+    private LogEntryV2CodecFactory() {
+    }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Decoder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Decoder.java
@@ -35,21 +35,17 @@ import com.google.protobuf.ZeroByteStringHelper;
 
 /**
  * V2 log entry decoder based on protobuf, see src/main/resources/log.proto
- * @author boyan(boyan@antfin.com)
  *
+ * @author boyan(boyan@antfin.com)
  */
 public class V2Decoder implements LogEntryDecoder {
 
-    private V2Decoder() {
-
-    }
-
     private static final Logger   LOG      = LoggerFactory.getLogger(V2Decoder.class);
+
     public static final V2Decoder INSTANCE = new V2Decoder();
 
     @Override
     public LogEntry decode(final byte[] bs) {
-
         if (bs == null || bs.length < LogEntryV2CodecFactory.HEADER_SIZE) {
             return null;
         }
@@ -67,10 +63,9 @@ public class V2Decoder implements LogEntryDecoder {
         // Ignored reserved
         i += LogEntryV2CodecFactory.RESERVED.length;
         try {
+            final PBLogEntry entry = PBLogEntry.parseFrom(ZeroByteStringHelper.wrap(bs, i, bs.length - i));
 
-            PBLogEntry entry = PBLogEntry.parseFrom(ZeroByteStringHelper.wrap(bs, i, bs.length - i));
-
-            LogEntry log = new LogEntry();
+            final LogEntry log = new LogEntry();
             log.setType(entry.getType());
             log.getId().setIndex(entry.getIndex());
             log.getId().setTerm(entry.getTerm());
@@ -79,15 +74,15 @@ public class V2Decoder implements LogEntryDecoder {
                 log.setChecksum(entry.getChecksum());
             }
             if (entry.getPeersCount() > 0) {
-                List<PeerId> peers = new ArrayList<>(entry.getPeersCount());
-                for (ByteString bstring : entry.getPeersList()) {
+                final List<PeerId> peers = new ArrayList<>(entry.getPeersCount());
+                for (final ByteString bstring : entry.getPeersList()) {
                     peers.add(JRaftUtils.getPeerId(AsciiStringUtil.unsafeDecode(bstring)));
                 }
                 log.setPeers(peers);
             }
             if (entry.getOldPeersCount() > 0) {
-                List<PeerId> peers = new ArrayList<>(entry.getOldPeersCount());
-                for (ByteString bstring : entry.getOldPeersList()) {
+                final List<PeerId> peers = new ArrayList<>(entry.getOldPeersCount());
+                for (final ByteString bstring : entry.getOldPeersList()) {
                     peers.add(JRaftUtils.getPeerId(AsciiStringUtil.unsafeDecode(bstring)));
                 }
                 log.setOldPeers(peers);
@@ -98,10 +93,12 @@ public class V2Decoder implements LogEntryDecoder {
             }
 
             return log;
-        } catch (InvalidProtocolBufferException e) {
+        } catch (final InvalidProtocolBufferException e) {
             LOG.error("Fail to decode pb log entry", e);
             return null;
         }
     }
 
+    private V2Decoder() {
+    }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
@@ -99,12 +99,12 @@ public class V2Encoder implements LogEntryEncoder {
         }
 
         // write body
-        toByteArray(pbLogEntry, ret, i, bodyLen);
+        writeToByteArray(pbLogEntry, ret, i, bodyLen);
 
         return ret;
     }
 
-    private void toByteArray(final PBLogEntry pbLogEntry, final byte[] array, final int offset, final int len) {
+    private void writeToByteArray(final PBLogEntry pbLogEntry, final byte[] array, final int offset, final int len) {
         final CodedOutputStream output = CodedOutputStream.newInstance(array, offset, len);
         try {
             pbLogEntry.writeTo(output);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
@@ -88,18 +88,18 @@ public class V2Encoder implements LogEntryEncoder {
         final byte[] ret = new byte[LogEntryV2CodecFactory.HEADER_SIZE + bodyLen];
 
         // write header
-        int index = 0;
-        for (int i = 0; i < LogEntryV2CodecFactory.MAGIC_BYTES.length; i++) {
-            ret[index++] = LogEntryV2CodecFactory.MAGIC_BYTES[i];
+        int i = 0;
+        for (; i < LogEntryV2CodecFactory.MAGIC_BYTES.length; i++) {
+            ret[i] = LogEntryV2CodecFactory.MAGIC_BYTES[i];
         }
-        ret[index++] = LogEntryV2CodecFactory.VERSION;
+        ret[i++] = LogEntryV2CodecFactory.VERSION;
         // avoid memory copy for only 3 bytes
-        for (int i = 0; i < LogEntryV2CodecFactory.RESERVED.length; i++) {
-            ret[index++] = LogEntryV2CodecFactory.RESERVED[i];
+        for (; i < LogEntryV2CodecFactory.HEADER_SIZE; i++) {
+            ret[i] = LogEntryV2CodecFactory.RESERVED[i - LogEntryV2CodecFactory.RESERVED.length];
         }
 
         // write body
-        toByteArray(pbLogEntry, ret, index, bodyLen);
+        toByteArray(pbLogEntry, ret, i, bodyLen);
 
         return ret;
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
@@ -95,7 +95,7 @@ public class V2Encoder implements LogEntryEncoder {
         ret[i++] = LogEntryV2CodecFactory.VERSION;
         // avoid memory copy for only 3 bytes
         for (; i < LogEntryV2CodecFactory.HEADER_SIZE; i++) {
-            ret[i] = LogEntryV2CodecFactory.RESERVED[i - LogEntryV2CodecFactory.RESERVED.length];
+            ret[i] = LogEntryV2CodecFactory.RESERVED[i - LogEntryV2CodecFactory.MAGIC_BYTES.length - 1];
         }
 
         // write body

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.jraft.entity.codec.v2;
 
+import java.io.IOException;
 import java.util.List;
 
 import com.alipay.sofa.jraft.entity.LogEntry;
@@ -26,24 +27,21 @@ import com.alipay.sofa.jraft.entity.codec.v2.LogOutter.PBLogEntry;
 import com.alipay.sofa.jraft.util.AsciiStringUtil;
 import com.alipay.sofa.jraft.util.Requires;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.ZeroByteStringHelper;
 
 /**
  * V2 log entry encoder based on protobuf, see src/main/resources/log.proto
- * @author boyan(boyan@antfin.com)
  *
+ * @author boyan(boyan@antfin.com)
  */
 public class V2Encoder implements LogEntryEncoder {
 
-    private V2Encoder() {
-
-    }
+    public static final V2Encoder INSTANCE = new V2Encoder();
 
     private static boolean hasPeers(final List<PeerId> peers) {
         return peers != null && !peers.isEmpty();
     }
-
-    public static final V2Encoder INSTANCE = new V2Encoder();
 
     private void encodePeers(final PBLogEntry.Builder builder, final List<PeerId> peers) {
         int size = peers.size();
@@ -63,18 +61,18 @@ public class V2Encoder implements LogEntryEncoder {
     public byte[] encode(final LogEntry log) {
         Requires.requireNonNull(log, "Null log");
 
-        LogId logId = log.getId();
-        PBLogEntry.Builder builder = PBLogEntry.newBuilder() //
+        final LogId logId = log.getId();
+        final PBLogEntry.Builder builder = PBLogEntry.newBuilder() //
             .setType(log.getType()) //
             .setIndex(logId.getIndex()) //
             .setTerm(logId.getTerm());
 
-        List<PeerId> peers = log.getPeers();
+        final List<PeerId> peers = log.getPeers();
         if (hasPeers(peers)) {
             encodePeers(builder, peers);
         }
 
-        List<PeerId> oldPeers = log.getOldPeers();
+        final List<PeerId> oldPeers = log.getOldPeers();
         if (hasPeers(oldPeers)) {
             encodeOldPeers(builder, oldPeers);
         }
@@ -85,17 +83,37 @@ public class V2Encoder implements LogEntryEncoder {
 
         builder.setData(log.getData() != null ? ZeroByteStringHelper.wrap(log.getData()) : ByteString.EMPTY);
 
-        byte[] bs = builder.build().toByteArray();
+        final PBLogEntry pbLogEntry = builder.build();
+        final int bodyLen = pbLogEntry.getSerializedSize();
+        final byte[] resultBytes = new byte[LogEntryV2CodecFactory.HEADER_SIZE + bodyLen];
 
-        byte[] ret = new byte[LogEntryV2CodecFactory.HEADER_SIZE + bs.length];
+        // write header
         int i = 0;
         for (; i < LogEntryV2CodecFactory.MAGIC_BYTES.length; i++) {
-            ret[i] = LogEntryV2CodecFactory.MAGIC_BYTES[i];
+            resultBytes[i] = LogEntryV2CodecFactory.MAGIC_BYTES[i];
         }
-        ret[i++] = LogEntryV2CodecFactory.VERSION;
-        System.arraycopy(LogEntryV2CodecFactory.RESERVED, 0, ret, i, LogEntryV2CodecFactory.RESERVED.length);
-        i += LogEntryV2CodecFactory.RESERVED.length;
-        System.arraycopy(bs, 0, ret, i, bs.length);
-        return ret;
+        resultBytes[i++] = LogEntryV2CodecFactory.VERSION;
+        // avoid memory copy for 3 bytes
+        for (int j = 0; j < LogEntryV2CodecFactory.RESERVED.length; j++) {
+            resultBytes[i++] = LogEntryV2CodecFactory.RESERVED[j];
+        }
+
+        // write body
+        toByteArray(pbLogEntry, resultBytes, i, bodyLen);
+
+        return resultBytes;
+    }
+
+    private void toByteArray(final PBLogEntry pbLogEntry, final byte[] array, final int offset, final int len) {
+        final CodedOutputStream output = CodedOutputStream.newInstance(array, offset, len);
+        try {
+            pbLogEntry.writeTo(output);
+        } catch (final IOException e) {
+            throw new RuntimeException(
+                "Serializing PBLogEntry to a byte array threw an IOException (should never happen).", e);
+        }
+    }
+
+    private V2Encoder() {
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v2/V2Encoder.java
@@ -85,29 +85,30 @@ public class V2Encoder implements LogEntryEncoder {
 
         final PBLogEntry pbLogEntry = builder.build();
         final int bodyLen = pbLogEntry.getSerializedSize();
-        final byte[] resultBytes = new byte[LogEntryV2CodecFactory.HEADER_SIZE + bodyLen];
+        final byte[] ret = new byte[LogEntryV2CodecFactory.HEADER_SIZE + bodyLen];
 
         // write header
-        int i = 0;
-        for (; i < LogEntryV2CodecFactory.MAGIC_BYTES.length; i++) {
-            resultBytes[i] = LogEntryV2CodecFactory.MAGIC_BYTES[i];
+        int index = 0;
+        for (int i = 0; i < LogEntryV2CodecFactory.MAGIC_BYTES.length; i++) {
+            ret[index++] = LogEntryV2CodecFactory.MAGIC_BYTES[i];
         }
-        resultBytes[i++] = LogEntryV2CodecFactory.VERSION;
-        // avoid memory copy for 3 bytes
-        for (int j = 0; j < LogEntryV2CodecFactory.RESERVED.length; j++) {
-            resultBytes[i++] = LogEntryV2CodecFactory.RESERVED[j];
+        ret[index++] = LogEntryV2CodecFactory.VERSION;
+        // avoid memory copy for only 3 bytes
+        for (int i = 0; i < LogEntryV2CodecFactory.RESERVED.length; i++) {
+            ret[index++] = LogEntryV2CodecFactory.RESERVED[i];
         }
 
         // write body
-        toByteArray(pbLogEntry, resultBytes, i, bodyLen);
+        toByteArray(pbLogEntry, ret, index, bodyLen);
 
-        return resultBytes;
+        return ret;
     }
 
     private void toByteArray(final PBLogEntry pbLogEntry, final byte[] array, final int offset, final int len) {
         final CodedOutputStream output = CodedOutputStream.newInstance(array, offset, len);
         try {
             pbLogEntry.writeTo(output);
+            output.checkNoSpaceLeft();
         } catch (final IOException e) {
             throw new RuntimeException(
                 "Serializing PBLogEntry to a byte array threw an IOException (should never happen).", e);


### PR DESCRIPTION
### Motivation:

Avoid some memory copy

### Modification:

1. Avoid pd.toBytesArray(), use stream writeTo
2. Avoid memory copy with only 3 bytes on 'RESERVED' of header

### Result:

the perf test on my mac：

```
V1 codec cost:1090 ms.
Total log size:1205400000 bytes.
V2 codec cost:919 ms.
Total log size:1183706496 bytes.

V1 codec cost:1015 ms.
Total log size:1205400000 bytes.
V2 codec cost:994 ms.
Total log size:1183706496 bytes.

V1 codec cost:1237 ms.
Total log size:1205400000 bytes.
V2 codec cost:911 ms.
Total log size:1183706496 bytes.
```
