### PR TITLE
Feat/sequence step0

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -81,7 +81,7 @@ public class LogManagerImpl implements LogManager {
     private long                                             nextWaitId;
     private LogId                                            diskId                = new LogId(0, 0);
     private LogId                                            appliedId             = new LogId(0, 0);
-    //TODO  use a lock-free concurrent list instead?
+    // TODO  use a lock-free concurrent list instead?
     private ArrayDeque<LogEntry>                             logsInMemory          = new ArrayDeque<>();
     private volatile long                                    firstLogIndex;
     private volatile long                                    lastLogIndex;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -99,7 +99,8 @@ public class LogManagerImpl implements LogManager {
         RESET, // reset
         TRUNCATE_PREFIX, // truncate log from prefix
         TRUNCATE_SUFFIX, // truncate log from suffix
-        SHUTDOWN, LAST_LOG_ID // get last log id
+        SHUTDOWN, //
+        LAST_LOG_ID // get last log id
     }
 
     private static class StableClosureEvent {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
@@ -58,7 +58,6 @@ import com.alipay.sofa.jraft.rhea.cmd.store.ResetSequenceResponse;
 import com.alipay.sofa.jraft.rhea.cmd.store.ScanRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.ScanResponse;
 import com.alipay.sofa.jraft.rhea.errors.Errors;
-import com.alipay.sofa.jraft.rhea.errors.InvalidParameterException;
 import com.alipay.sofa.jraft.rhea.metadata.RegionEpoch;
 import com.alipay.sofa.jraft.rhea.storage.BaseKVStoreClosure;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
@@ -66,6 +65,7 @@ import com.alipay.sofa.jraft.rhea.storage.NodeExecutor;
 import com.alipay.sofa.jraft.rhea.storage.RawKVStore;
 import com.alipay.sofa.jraft.rhea.storage.Sequence;
 import com.alipay.sofa.jraft.rhea.util.ByteArray;
+import com.alipay.sofa.jraft.rhea.util.KVParameterRequires;
 import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
 import com.alipay.sofa.jraft.rhea.util.concurrent.DistributedLock;
 
@@ -103,13 +103,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "put.key");
-            final byte[] value = requireNonNull(request.getValue(), "put.value");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "put.key");
+            final byte[] value = KVParameterRequires.requireNonNull(request.getValue(), "put.value");
             this.rawKVStore.put(key, value, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -132,12 +132,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final List<KVEntry> kvEntries = requireNonEmpty(request.getKvEntries(), "put.kvEntries");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final List<KVEntry> kvEntries = KVParameterRequires
+                .requireNonEmpty(request.getKvEntries(), "put.kvEntries");
             this.rawKVStore.put(kvEntries, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -160,13 +161,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "putIfAbsent.key");
-            final byte[] value = requireNonNull(request.getValue(), "putIfAbsent.value");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "putIfAbsent.key");
+            final byte[] value = KVParameterRequires.requireNonNull(request.getValue(), "putIfAbsent.value");
             this.rawKVStore.putIfAbsent(key, value, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((byte[]) getData());
                     } else {
@@ -189,13 +190,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "getAndPut.key");
-            final byte[] value = requireNonNull(request.getValue(), "getAndPut.value");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "getAndPut.key");
+            final byte[] value = KVParameterRequires.requireNonNull(request.getValue(), "getAndPut.value");
             this.rawKVStore.getAndPut(key, value, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((byte[]) getData());
                     } else {
@@ -218,12 +219,12 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "delete.key");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "delete.key");
             this.rawKVStore.delete(key, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -246,13 +247,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] startKey = requireNonNull(request.getStartKey(), "deleteRange.startKey");
-            final byte[] endKey = requireNonNull(request.getEndKey(), "deleteRange.endKey");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] startKey = KVParameterRequires.requireNonNull(request.getStartKey(), "deleteRange.startKey");
+            final byte[] endKey = KVParameterRequires.requireNonNull(request.getEndKey(), "deleteRange.endKey");
             this.rawKVStore.deleteRange(startKey, endKey, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -275,13 +276,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "merge.key");
-            final byte[] value = requireNonNull(request.getValue(), "merge.value");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "merge.key");
+            final byte[] value = KVParameterRequires.requireNonNull(request.getValue(), "merge.value");
             this.rawKVStore.merge(key, value, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -304,12 +305,12 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "get.key");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "get.key");
             this.rawKVStore.get(key, request.isReadOnlySafe(), new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((byte[]) getData());
                     } else {
@@ -332,13 +333,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final List<byte[]> keys = requireNonEmpty(request.getKeys(), "multiGet.keys");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final List<byte[]> keys = KVParameterRequires.requireNonEmpty(request.getKeys(), "multiGet.keys");
             this.rawKVStore.multiGet(keys, request.isReadOnlySafe(), new BaseKVStoreClosure() {
 
                 @SuppressWarnings("unchecked")
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Map<ByteArray, byte[]>) getData());
                     } else {
@@ -361,13 +362,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
             this.rawKVStore.scan(request.getStartKey(), request.getEndKey(), request.getLimit(),
                 request.isReadOnlySafe(), new BaseKVStoreClosure() {
 
                     @SuppressWarnings("unchecked")
                     @Override
-                    public void run(Status status) {
+                    public void run(final Status status) {
                         if (status.isOk()) {
                             response.setValue((List<KVEntry>) getData());
                         } else {
@@ -390,13 +391,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] seqKey = requireNonNull(request.getSeqKey(), "sequence.seqKey");
-            final int step = requirePositive(request.getStep(), "sequence.step");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] seqKey = KVParameterRequires.requireNonNull(request.getSeqKey(), "sequence.seqKey");
+            final int step = KVParameterRequires.requireNonNegative(request.getStep(), "sequence.step");
             this.rawKVStore.getSequence(seqKey, step, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Sequence) getData());
                     } else {
@@ -419,12 +420,12 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] seqKey = requireNonNull(request.getSeqKey(), "sequence.seqKey");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] seqKey = KVParameterRequires.requireNonNull(request.getSeqKey(), "sequence.seqKey");
             this.rawKVStore.resetSequence(seqKey, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -447,16 +448,17 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "lock.key");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "lock.key");
             final byte[] fencingKey = this.regionEngine.getRegion().getStartKey();
-            final DistributedLock.Acquirer acquirer = requireNonNull(request.getAcquirer(), "lock.acquirer");
-            requireNonNull(acquirer.getId(), "lock.id");
-            requirePositive(acquirer.getLeaseMillis(), "lock.leaseMillis");
+            final DistributedLock.Acquirer acquirer = KVParameterRequires.requireNonNull(request.getAcquirer(),
+                "lock.acquirer");
+            KVParameterRequires.requireNonNull(acquirer.getId(), "lock.id");
+            KVParameterRequires.requirePositive(acquirer.getLeaseMillis(), "lock.leaseMillis");
             this.rawKVStore.tryLockWith(key, fencingKey, request.isKeepLease(), acquirer, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((DistributedLock.Owner) getData());
                     } else {
@@ -479,14 +481,15 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final byte[] key = requireNonNull(request.getKey(), "unlock.key");
-            final DistributedLock.Acquirer acquirer = requireNonNull(request.getAcquirer(), "lock.acquirer");
-            requireNonNull(acquirer.getId(), "lock.id");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final byte[] key = KVParameterRequires.requireNonNull(request.getKey(), "unlock.key");
+            final DistributedLock.Acquirer acquirer = KVParameterRequires.requireNonNull(request.getAcquirer(),
+                "lock.acquirer");
+            KVParameterRequires.requireNonNull(acquirer.getId(), "lock.id");
             this.rawKVStore.releaseLockWith(key, acquirer, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((DistributedLock.Owner) getData());
                     } else {
@@ -509,12 +512,13 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionId(getRegionId());
         response.setRegionEpoch(getRegionEpoch());
         try {
-            checkRegionEpoch(request);
-            final NodeExecutor executor = requireNonNull(request.getNodeExecutor(), "node.executor");
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final NodeExecutor executor = KVParameterRequires
+                .requireNonNull(request.getNodeExecutor(), "node.executor");
             this.rawKVStore.execute(executor, true, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -538,11 +542,12 @@ public class DefaultRegionKVService implements RegionKVService {
         response.setRegionEpoch(getRegionEpoch());
         try {
             // do not need to check the region epoch
-            final Long newRegionId = requireNonNull(request.getNewRegionId(), "rangeSplit.newRegionId");
+            final Long newRegionId = KVParameterRequires.requireNonNull(request.getNewRegionId(),
+                "rangeSplit.newRegionId");
             this.regionEngine.getStoreEngine().applySplit(request.getRegionId(), newRegionId, new BaseKVStoreClosure() {
 
                 @Override
-                public void run(Status status) {
+                public void run(final Status status) {
                     if (status.isOk()) {
                         response.setValue((Boolean) getData());
                     } else {
@@ -556,52 +561,6 @@ public class DefaultRegionKVService implements RegionKVService {
             response.setError(Errors.forException(t));
             closure.sendResponse(response);
         }
-    }
-
-    void checkRegionEpoch(final BaseRequest request) {
-        RegionEpoch currentEpoch = getRegionEpoch();
-        RegionEpoch requestEpoch = request.getRegionEpoch();
-        if (currentEpoch.equals(requestEpoch)) {
-            return;
-        }
-        if (currentEpoch.getConfVer() != requestEpoch.getConfVer()) {
-            throw Errors.INVALID_REGION_MEMBERSHIP.exception();
-        }
-        if (currentEpoch.getVersion() != requestEpoch.getVersion()) {
-            throw Errors.INVALID_REGION_VERSION.exception();
-        }
-        throw Errors.INVALID_REGION_EPOCH.exception();
-    }
-
-    private static <T> T requireNonNull(final T target, final String message) {
-        if (target == null) {
-            throw new InvalidParameterException(message);
-        }
-        return target;
-    }
-
-    private static <T> List<T> requireNonEmpty(final List<T> target, final String message) {
-        requireNonNull(target, message);
-        if (target.isEmpty()) {
-            throw new InvalidParameterException(message);
-        }
-        return target;
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static int requirePositive(final int value, final String message) {
-        if (value <= 0) {
-            throw new InvalidParameterException(message);
-        }
-        return value;
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static long requirePositive(final long value, final String message) {
-        if (value <= 0) {
-            throw new InvalidParameterException(message);
-        }
-        return value;
     }
 
     private static void setFailure(final BaseRequest request, final BaseResponse<?> response, final Status status,

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -650,7 +650,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
     public CompletableFuture<Sequence> getSequence(final byte[] seqKey, final int step) {
         checkState();
         Requires.requireNonNull(seqKey, "seqKey");
-        Requires.requireTrue(step > 0, "step must > 0");
+        Requires.requireTrue(step >= 0, "step must >= 0");
         final CompletableFuture<Sequence> future = new CompletableFuture<>();
         internalGetSequence(seqKey, step, future, this.failoverRetries, null);
         return future;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
@@ -242,7 +242,10 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
 
     /**
      * Get a globally unique auto-increment sequence.
-     * <p>
+     *
+     * If {@code step}==0, then it is a read-only operation and only gets the
+     * latest value.
+     *
      * Be careful do not to try to get or update the value of {@code seqKey}
      * by other methods, you won't get it.
      *
@@ -483,13 +486,13 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
      * every process flows approximately at the same rate, with an error
      * which is small compared to the auto-release time of the lock.
      *
-     * @param target    key of the distributed lock that acquired.
-     * @param lease     the lease time for the distributed lock to live.
-     * @param unit      the time unit of the {@code expire} argument.
-     * @param watchdog  if the watchdog is not null, it will auto keep
-     *                  lease of current lock, otherwise won't keep lease,
-     *                  this method dose not pay attention to the life cycle
-     *                  of watchdog, please maintain it yourself.
+     * @param target   key of the distributed lock that acquired.
+     * @param lease    the lease time for the distributed lock to live.
+     * @param unit     the time unit of the {@code expire} argument.
+     * @param watchdog if the watchdog is not null, it will auto keep
+     *                 lease of current lock, otherwise won't keep lease,
+     *                 this method dose not pay attention to the life cycle
+     *                 of watchdog, please maintain it yourself.
      * @return a distributed lock instance.
      */
     DistributedLock<byte[]> getDistributedLock(final byte[] target, final long lease, final TimeUnit unit,

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
@@ -243,9 +243,6 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
     /**
      * Get a globally unique auto-increment sequence.
      *
-     * If {@code step}==0, then it is a read-only operation and only gets the
-     * latest value.
-     *
      * Be careful do not to try to get or update the value of {@code seqKey}
      * by other methods, you won't get it.
      *
@@ -269,6 +266,33 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
      * @see #getSequence(byte[], int)
      */
     Sequence bGetSequence(final String seqKey, final int step);
+
+    /**
+     * Gets the latest sequence start value, this is a read-only operation.
+     *
+     * Equivalent to {@code getSequence(seqKey, 0)}.
+     *
+     * @see #getSequence(byte[], int)
+     *
+     * @param seqKey the key of sequence
+     * @return the latest sequence value
+     */
+    CompletableFuture<Long> getLatestSequence(final byte[] seqKey);
+
+    /**
+     * @see #getLatestSequence(byte[])
+     */
+    CompletableFuture<Long> getLatestSequence(final String seqKey);
+
+    /**
+     * @see #getLatestSequence(byte[])
+     */
+    Long bGetLatestSequence(final byte[] seqKey);
+
+    /**
+     * @see #getLatestSequence(byte[])
+     */
+    Long bGetLatestSequence(final String seqKey);
 
     /**
      * Reset the sequence to 0.

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
@@ -82,6 +82,10 @@ public abstract class BaseRawKVStore<T> implements RawKVStore, Lifecycle<T> {
         }
     }
 
+    public long getSafeEndValueForSequence(final long startVal, final int step) {
+        return Math.max(startVal, Long.MAX_VALUE - step < startVal ? Long.MAX_VALUE : startVal + step);
+    }
+
     /**
      * Note: This is not a very precise behavior, don't rely on its accuracy.
      */

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
@@ -163,7 +163,16 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
             final ByteArray wrappedKey = ByteArray.wrap(seqKey);
             Long startVal = this.sequenceDB.get(wrappedKey);
             startVal = startVal == null ? 0 : startVal;
-            final long endVal = Math.max(startVal, (startVal + step) & Long.MAX_VALUE);
+            if (step < 0) {
+                // never get here
+                setFailure(closure, "Fail to [GET_SEQUENCE], step must >= 0");
+                return;
+            }
+            if (step == 0) {
+                setSuccess(closure, new Sequence(startVal, startVal));
+                return;
+            }
+            final long endVal = getSafeEndValueForSequence(startVal, step);
             if (startVal != endVal) {
                 this.sequenceDB.put(wrappedKey, endVal);
             }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
@@ -164,7 +164,9 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
             Long startVal = this.sequenceDB.get(wrappedKey);
             startVal = startVal == null ? 0 : startVal;
             final long endVal = Math.max(startVal, (startVal + step) & Long.MAX_VALUE);
-            this.sequenceDB.put(wrappedKey, endVal);
+            if (startVal != endVal) {
+                this.sequenceDB.put(wrappedKey, endVal);
+            }
             setSuccess(closure, new Sequence(startVal, endVal));
         } catch (final Exception e) {
             LOG.error("Fail to [GET_SEQUENCE], [key = {}, step = {}], {}.", Arrays.toString(seqKey), step,

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -327,7 +327,16 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             } else {
                 startVal = Bits.getLong(prevBytesVal, 0);
             }
-            final long endVal = Math.max(startVal, (startVal + step) & Long.MAX_VALUE);
+            if (step < 0) {
+                // never get here
+                setFailure(closure, "Fail to [GET_SEQUENCE], step must >= 0");
+                return;
+            }
+            if (step == 0) {
+                setSuccess(closure, new Sequence(startVal, startVal));
+                return;
+            }
+            final long endVal = getSafeEndValueForSequence(startVal, step);
             if (startVal != endVal) {
                 final byte[] newBytesVal = new byte[8];
                 Bits.putLong(newBytesVal, 0, endVal);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -328,9 +328,11 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                 startVal = Bits.getLong(prevBytesVal, 0);
             }
             final long endVal = Math.max(startVal, (startVal + step) & Long.MAX_VALUE);
-            final byte[] newBytesVal = new byte[8];
-            Bits.putLong(newBytesVal, 0, endVal);
-            this.db.put(this.sequenceHandle, this.writeOptions, seqKey, newBytesVal);
+            if (startVal != endVal) {
+                final byte[] newBytesVal = new byte[8];
+                Bits.putLong(newBytesVal, 0, endVal);
+                this.db.put(this.sequenceHandle, this.writeOptions, seqKey, newBytesVal);
+            }
             setSuccess(closure, new Sequence(startVal, endVal));
         } catch (final Exception e) {
             LOG.error("Fail to [GET_SEQUENCE], [key = {}, step = {}], {}.", Arrays.toString(seqKey), step,

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/KVParameterRequires.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/KVParameterRequires.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.util;
+
+import java.util.List;
+
+import com.alipay.sofa.jraft.rhea.cmd.store.BaseRequest;
+import com.alipay.sofa.jraft.rhea.errors.Errors;
+import com.alipay.sofa.jraft.rhea.errors.InvalidParameterException;
+import com.alipay.sofa.jraft.rhea.metadata.RegionEpoch;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public final class KVParameterRequires {
+
+    public static void requireSameEpoch(final BaseRequest request, final RegionEpoch current) {
+        RegionEpoch requestEpoch = request.getRegionEpoch();
+        if (current.equals(requestEpoch)) {
+            return;
+        }
+        if (current.getConfVer() != requestEpoch.getConfVer()) {
+            throw Errors.INVALID_REGION_MEMBERSHIP.exception();
+        }
+        if (current.getVersion() != requestEpoch.getVersion()) {
+            throw Errors.INVALID_REGION_VERSION.exception();
+        }
+        throw Errors.INVALID_REGION_EPOCH.exception();
+    }
+
+    public static <T> T requireNonNull(final T target, final String message) {
+        if (target == null) {
+            throw new InvalidParameterException(message);
+        }
+        return target;
+    }
+
+    public static <T> List<T> requireNonEmpty(final List<T> target, final String message) {
+        requireNonNull(target, message);
+        if (target.isEmpty()) {
+            throw new InvalidParameterException(message);
+        }
+        return target;
+    }
+
+    public static int requireNonNegative(final int value, final String message) {
+        if (value < 0) {
+            throw new InvalidParameterException(message);
+        }
+        return value;
+    }
+
+    public static long requireNonNegative(final long value, final String message) {
+        if (value < 0) {
+            throw new InvalidParameterException(message);
+        }
+        return value;
+    }
+
+    public static int requirePositive(final int value, final String message) {
+        if (value <= 0) {
+            throw new InvalidParameterException(message);
+        }
+        return value;
+    }
+
+    public static long requirePositive(final long value, final String message) {
+        if (value <= 0) {
+            throw new InvalidParameterException(message);
+        }
+        return value;
+    }
+
+    private KVParameterRequires() {
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -32,8 +32,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.options.MemoryDBOptions;
+import com.alipay.sofa.jraft.rhea.storage.BaseKVStoreClosure;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.storage.KVIterator;
 import com.alipay.sofa.jraft.rhea.storage.KVStoreAccessHelper;
@@ -317,6 +319,32 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
         }.apply(this.kvStore);
         assertEquals(sequence4.getStartValue(), 11);
         assertEquals(sequence4.getEndValue(), 11);
+
+        KVStoreClosure assertFailed = new BaseKVStoreClosure() {
+            @Override
+            public void run(Status status) {
+                assertEquals("Fail to [GET_SEQUENCE], step must >= 0", status.getErrorMsg());
+            }
+        };
+        this.kvStore.getSequence(seqKey, -1, assertFailed);
+    }
+
+    /**
+     * Test method: {@link MemoryRawKVStore#getSafeEndValueForSequence(long, int)}
+     */
+    @Test
+    public void getSafeEndValueForSequenceTest() {
+        long startVal = 1;
+        assertEquals(2, this.kvStore.getSafeEndValueForSequence(startVal, 1));
+        startVal = Long.MAX_VALUE - 1;
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 1));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 2));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, Integer.MAX_VALUE));
+        startVal = Long.MAX_VALUE;
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 0));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 1));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 2));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, Integer.MAX_VALUE));
     }
 
     /**

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -307,6 +307,16 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
         }.apply(this.kvStore);
         assertEquals(sequence3.getStartValue(), 0);
         assertEquals(sequence3.getEndValue(), 11);
+
+        // read-only
+        Sequence sequence4 = new SyncKVStore<Sequence>() {
+            @Override
+            public void execute(RawKVStore kvStore, KVStoreClosure closure) {
+                kvStore.getSequence(seqKey, 0, closure);
+            }
+        }.apply(this.kvStore);
+        assertEquals(sequence4.getStartValue(), 11);
+        assertEquals(sequence4.getEndValue(), 11);
     }
 
     /**

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
@@ -296,9 +296,8 @@ public abstract class AbstractRheaKVStoreTest extends RheaKVTestCluster {
         assertEquals(sequence.getEndValue(), 199);
 
         // get-only, do not update
-        sequence = store.bGetSequence(seqKey, 0);
-        assertEquals(sequence.getStartValue(), 199);
-        assertEquals(sequence.getEndValue(), 199);
+        final long latestVal = store.bGetLatestSequence(seqKey);
+        assertEquals(latestVal, 199);
 
         sequence = store.bGetSequence(seqKey, 10);
         assertEquals(sequence.getStartValue(), 199);

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
@@ -295,6 +295,11 @@ public abstract class AbstractRheaKVStoreTest extends RheaKVTestCluster {
         assertEquals(sequence.getStartValue(), 0);
         assertEquals(sequence.getEndValue(), 199);
 
+        // get-only, do not update
+        sequence = store.bGetSequence(seqKey, 0);
+        assertEquals(sequence.getStartValue(), 199);
+        assertEquals(sequence.getEndValue(), 199);
+
         sequence = store.bGetSequence(seqKey, 10);
         assertEquals(sequence.getStartValue(), 199);
         assertEquals(sequence.getEndValue(), 209);

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
@@ -34,9 +34,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
 import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.options.RocksDBOptions;
+import com.alipay.sofa.jraft.rhea.storage.BaseKVStoreClosure;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.storage.KVIterator;
 import com.alipay.sofa.jraft.rhea.storage.KVStoreAccessHelper;
@@ -251,6 +253,32 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
         }.apply(this.kvStore);
         assertEquals(sequence4.getStartValue(), 11);
         assertEquals(sequence4.getEndValue(), 11);
+
+        KVStoreClosure assertFailed = new BaseKVStoreClosure() {
+            @Override
+            public void run(Status status) {
+                assertEquals("Fail to [GET_SEQUENCE], step must >= 0", status.getErrorMsg());
+            }
+        };
+        this.kvStore.getSequence(seqKey, -1, assertFailed);
+    }
+
+    /**
+     * Test method: {@link RocksRawKVStore#getSafeEndValueForSequence(long, int)}
+     */
+    @Test
+    public void getSafeEndValueForSequenceTest() {
+        long startVal = 1;
+        assertEquals(2, this.kvStore.getSafeEndValueForSequence(startVal, 1));
+        startVal = Long.MAX_VALUE - 1;
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 1));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 2));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, Integer.MAX_VALUE));
+        startVal = Long.MAX_VALUE;
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 0));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 1));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, 2));
+        assertEquals(Long.MAX_VALUE, this.kvStore.getSafeEndValueForSequence(startVal, Integer.MAX_VALUE));
     }
 
     /**

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
@@ -241,6 +241,16 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
         }.apply(this.kvStore);
         assertEquals(sequence3.getStartValue(), 0);
         assertEquals(sequence3.getEndValue(), 11);
+
+        // read-only
+        Sequence sequence4 = new SyncKVStore<Sequence>() {
+            @Override
+            public void execute(RawKVStore kvStore, KVStoreClosure closure) {
+                kvStore.getSequence(seqKey, 0, closure);
+            }
+        }.apply(this.kvStore);
+        assertEquals(sequence4.getStartValue(), 11);
+        assertEquals(sequence4.getEndValue(), 11);
     }
 
     /**


### PR DESCRIPTION
### Motivation:

Each `getSequence` method call will lead to sequence increase by step, so other client or thread cannot get the latest sequence. In some scenes, users have to store this sequence in addition.

### Modification:

Allows `step` parameter can be zero. If step==0, then it is a read-only operation and only gets the latest value.

The read only `getSequence` can optimize with ReadIndex/Lease read

### Result:

Fixes #128 

