### PR TITLE
feat/close rpc crc

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RpcOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RpcOptions.java
@@ -39,31 +39,21 @@ public class RpcOptions {
     private int            rpcInstallSnapshotTimeout  = 5 * 60 * 1000;
 
     /**
-     * Rpc process thread pool size
+     * RPC process thread pool size
      * Default: 80
      */
     private int            rpcProcessorThreadPoolSize = 80;
 
     /**
+     * Whether to enable checksum for RPC.
+     * Default: false
+     */
+    private boolean        enableRpcChecksum          = false;
+
+    /**
      * Metric registry for RPC services, user should not use this field.
      */
     private MetricRegistry metricRegistry;
-
-    public MetricRegistry getMetricRegistry() {
-        return metricRegistry;
-    }
-
-    public void setMetricRegistry(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
-    }
-
-    public int getRpcProcessorThreadPoolSize() {
-        return this.rpcProcessorThreadPoolSize;
-    }
-
-    public void setRpcProcessorThreadPoolSize(int rpcProcessorThreadPoolSize) {
-        this.rpcProcessorThreadPoolSize = rpcProcessorThreadPoolSize;
-    }
 
     public int getRpcConnectTimeoutMs() {
         return this.rpcConnectTimeoutMs;
@@ -89,11 +79,35 @@ public class RpcOptions {
         this.rpcInstallSnapshotTimeout = rpcInstallSnapshotTimeout;
     }
 
+    public int getRpcProcessorThreadPoolSize() {
+        return this.rpcProcessorThreadPoolSize;
+    }
+
+    public void setRpcProcessorThreadPoolSize(int rpcProcessorThreadPoolSize) {
+        this.rpcProcessorThreadPoolSize = rpcProcessorThreadPoolSize;
+    }
+
+    public boolean isEnableRpcChecksum() {
+        return enableRpcChecksum;
+    }
+
+    public void setEnableRpcChecksum(boolean enableRpcChecksum) {
+        this.enableRpcChecksum = enableRpcChecksum;
+    }
+
+    public MetricRegistry getMetricRegistry() {
+        return metricRegistry;
+    }
+
+    public void setMetricRegistry(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
     @Override
     public String toString() {
         return "RpcOptions{" + "rpcConnectTimeoutMs=" + rpcConnectTimeoutMs + ", rpcDefaultTimeout="
                + rpcDefaultTimeout + ", rpcInstallSnapshotTimeout=" + rpcInstallSnapshotTimeout
-               + ", rpcProcessorThreadPoolSize=" + rpcProcessorThreadPoolSize + ", metricRegistry=" + metricRegistry
-               + '}';
+               + ", rpcProcessorThreadPoolSize=" + rpcProcessorThreadPoolSize + ", enableRpcChecksum="
+               + enableRpcChecksum + ", metricRegistry=" + metricRegistry + '}';
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/ProtobufMsgFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/ProtobufMsgFactory.java
@@ -55,10 +55,10 @@ public class ProtobufMsgFactory {
             List<FileDescriptor> resolveFDs = new ArrayList<>();
             for (FileDescriptorProto fdp : descriptorSet.getFileList()) {
 
-                FileDescriptor[] dpendencies = new FileDescriptor[resolveFDs.size()];
-                resolveFDs.toArray(dpendencies);
+                FileDescriptor[] dependencies = new FileDescriptor[resolveFDs.size()];
+                resolveFDs.toArray(dependencies);
 
-                FileDescriptor fd = FileDescriptor.buildFrom(fdp, dpendencies);
+                FileDescriptor fd = FileDescriptor.buildFrom(fdp, dependencies);
                 resolveFDs.add(fd);
                 for (Descriptor descriptor : fd.getMessageTypes()) {
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
@@ -85,8 +85,7 @@ public abstract class AbstractBoltClientService implements ClientService {
         this.rpcOptions = rpcOptions;
         this.rpcAddressParser = new JRaftRpcAddressParser();
         this.defaultInvokeCtx = new InvokeContext();
-        // default close crc of bolt rpc
-        this.defaultInvokeCtx.put(InvokeContext.BOLT_CRC_SWITCH, false);
+        this.defaultInvokeCtx.put(InvokeContext.BOLT_CRC_SWITCH, this.rpcOptions.isEnableRpcChecksum());
         return initRpcClient(this.rpcOptions.getRpcProcessorThreadPoolSize());
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alipay.remoting.InvokeCallback;
+import com.alipay.remoting.InvokeContext;
 import com.alipay.remoting.Url;
 import com.alipay.remoting.exception.RemotingException;
 import com.alipay.remoting.rpc.RpcClient;
@@ -65,34 +66,37 @@ public abstract class AbstractBoltClientService implements ClientService {
     protected ThreadPoolExecutor    rpcExecutor;
     protected RpcOptions            rpcOptions;
     protected JRaftRpcAddressParser rpcAddressParser;
+    protected InvokeContext         invokeCtx;
 
     public RpcClient getRpcClient() {
         return this.rpcClient;
     }
 
     @Override
-    public boolean isConnected(Endpoint endpoint) {
+    public boolean isConnected(final Endpoint endpoint) {
         return this.rpcClient.checkConnection(endpoint.toString());
     }
 
     @Override
-    public synchronized boolean init(RpcOptions rpcOptions) {
+    public synchronized boolean init(final RpcOptions rpcOptions) {
         if (this.rpcClient != null) {
             return true;
         }
         this.rpcOptions = rpcOptions;
-        final int rpcProcessorThreadPoolSize = this.rpcOptions.getRpcProcessorThreadPoolSize();
         this.rpcAddressParser = new JRaftRpcAddressParser();
-        return initRpcClient(rpcProcessorThreadPoolSize);
+        this.invokeCtx = new InvokeContext();
+        // close crc of bolt rpc
+        this.invokeCtx.put(InvokeContext.BOLT_CRC_SWITCH, false);
+        return initRpcClient(this.rpcOptions.getRpcProcessorThreadPoolSize());
     }
 
-    protected void configRpcClient(RpcClient rpcClient) {
+    protected void configRpcClient(final RpcClient rpcClient) {
         // NO-OP
     }
 
-    protected boolean initRpcClient(int rpcProcessorThreadPoolSize) {
+    protected boolean initRpcClient(final int rpcProcessorThreadPoolSize) {
         this.rpcClient = new RpcClient();
-        this.configRpcClient(rpcClient);
+        configRpcClient(this.rpcClient);
         this.rpcClient.init();
         this.rpcExecutor = ThreadPoolUtil.newThreadPool("JRaft-RPC-Processor", true, rpcProcessorThreadPoolSize / 3,
             rpcProcessorThreadPoolSize, 60L, new ArrayBlockingQueue<>(10000), new NamedThreadFactory(
@@ -115,44 +119,46 @@ public abstract class AbstractBoltClientService implements ClientService {
     }
 
     @Override
-    public boolean connect(Endpoint endpoint) {
+    public boolean connect(final Endpoint endpoint) {
         if (this.rpcClient == null) {
             throw new IllegalStateException("Client service is not inited.");
         }
-        if (this.isConnected(endpoint)) {
+        if (isConnected(endpoint)) {
             return true;
         }
         try {
-            final PingRequest req = PingRequest.newBuilder().setSendTimestamp(System.currentTimeMillis()).build();
-            final ErrorResponse resp = (ErrorResponse) rpcClient.invokeSync(endpoint.toString(), req,
-                rpcOptions.getRpcConnectTimeoutMs());
+            final PingRequest req = PingRequest.newBuilder() //
+                .setSendTimestamp(System.currentTimeMillis()) //
+                .build();
+            final ErrorResponse resp = (ErrorResponse) this.rpcClient.invokeSync(endpoint.toString(), req,
+                this.invokeCtx, this.rpcOptions.getRpcConnectTimeoutMs());
             return resp.getErrorCode() == 0;
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             return false;
         } catch (final RemotingException e) {
-            LOG.error("Fail to connect {}, remoting exception: {}", endpoint, e.getMessage());
+            LOG.error("Fail to connect {}, remoting exception: {}.", endpoint, e.getMessage());
             return false;
         }
     }
 
     @Override
-    public boolean disconnect(Endpoint endpoint) {
+    public boolean disconnect(final Endpoint endpoint) {
         LOG.info("Disconnect from {}", endpoint);
         this.rpcClient.closeConnection(endpoint.toString());
         return true;
     }
 
-    public <T extends Message> Future<Message> invokeWithDone(Endpoint endpoint, Message request,
-                                                              RpcResponseClosure<T> done, int timeoutMs) {
+    public <T extends Message> Future<Message> invokeWithDone(final Endpoint endpoint, final Message request,
+                                                              final RpcResponseClosure<T> done, final int timeoutMs) {
         final FutureImpl<Message> future = new FutureImpl<>();
         try {
             final Url rpcUrl = this.rpcAddressParser.parse(endpoint.toString());
-            this.rpcClient.invokeWithCallback(rpcUrl, request, new InvokeCallback() {
+            this.rpcClient.invokeWithCallback(rpcUrl, request, this.invokeCtx, new InvokeCallback() {
 
                 @SuppressWarnings("unchecked")
                 @Override
-                public void onResponse(Object result) {
+                public void onResponse(final Object result) {
                     if (future.isCancelled()) {
                         return;
                     }
@@ -173,7 +179,7 @@ public abstract class AbstractBoltClientService implements ClientService {
                         try {
                             done.run(status);
                         } catch (final Throwable t) {
-                            LOG.error("Fail to run RpcResponseClosure, the request is {}", request, t);
+                            LOG.error("Fail to run RpcResponseClosure, the request is {}.", request, t);
                         }
                     }
                     if (!future.isDone()) {
@@ -182,7 +188,7 @@ public abstract class AbstractBoltClientService implements ClientService {
                 }
 
                 @Override
-                public void onException(Throwable e) {
+                public void onException(final Throwable e) {
                     if (future.isCancelled()) {
                         return;
                     }
@@ -191,7 +197,7 @@ public abstract class AbstractBoltClientService implements ClientService {
                             done.run(new Status(e instanceof InvokeTimeoutException ? RaftError.ETIMEDOUT
                                 : RaftError.EINTERNAL, "RPC exception:" + e.getMessage()));
                         } catch (final Throwable t) {
-                            LOG.error("Fail to run RpcResponseClosure, the request is {}", request, t);
+                            LOG.error("Fail to run RpcResponseClosure, the request is {}.", request, t);
                         }
                     }
                     if (!future.isDone()) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AbstractBoltClientServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AbstractBoltClientServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.alipay.remoting.InvokeCallback;
+import com.alipay.remoting.InvokeContext;
 import com.alipay.remoting.Url;
 import com.alipay.remoting.exception.RemotingException;
 import com.alipay.remoting.rpc.RpcClient;
@@ -187,14 +188,16 @@ public class AbstractBoltClientServiceTest {
 
     @Test
     public void testInvokeWithDoneOnException() throws Exception {
+        InvokeContext invokeCtx = new InvokeContext();
+        invokeCtx.put(InvokeContext.BOLT_CRC_SWITCH, false);
         ArgumentCaptor<InvokeCallback> callbackArg = ArgumentCaptor.forClass(InvokeCallback.class);
         PingRequest request = TestUtils.createPingRequest();
 
         MockRpcResponseClosure<ErrorResponse> done = new MockRpcResponseClosure<>();
-        Future<Message> future = this.clientService.invokeWithDone(this.endpoint, request, done, -1);
+        Future<Message> future = this.clientService.invokeWithDone(this.endpoint, request, invokeCtx, done, -1);
         Url rpcUrl = this.rpcAddressParser.parse(this.endpoint.toString());
-        Mockito.verify(this.rpcClient).invokeWithCallback(eq(rpcUrl), eq(request), callbackArg.capture(),
-            eq(this.rpcOptions.getRpcDefaultTimeout()));
+        Mockito.verify(this.rpcClient).invokeWithCallback(eq(rpcUrl), eq(request), eq(invokeCtx),
+            callbackArg.capture(), eq(this.rpcOptions.getRpcDefaultTimeout()));
         InvokeCallback cb = callbackArg.getValue();
         assertNotNull(cb);
         assertNotNull(future);


### PR DESCRIPTION
### Motivation:

The raft log already has checksum, does not need checksum with bolt rpc any more.

### Modification:

Close bolt checksum in AbstractBoltClientService (only jraft use it).
Still open checksum when get snapshot file.

### Result:

Fixes #130 

