### PR TITLE
feat/add thread_pool_builder

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/JRaftUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/JRaftUtils.java
@@ -68,8 +68,15 @@ public final class JRaftUtils {
         if (number <= 0) {
             return null;
         }
-        return ThreadPoolUtil.newThreadPool(prefix, true, number, number, 60L, new SynchronousQueue<>(),
-            createThreadFactory(prefix));
+        return ThreadPoolUtil.newBuilder() //
+            .poolName(prefix) //
+            .enableMetric(true) //
+            .coreThreads(number) //
+            .maximumThreads(number) //
+            .keepAliveSeconds(60L) //
+            .workQueue(new SynchronousQueue<>()) //
+            .threadFactory(createThreadFactory(prefix)) //
+            .build();
     }
 
     /**

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
@@ -94,9 +94,15 @@ public abstract class AbstractBoltClientService implements ClientService {
         this.rpcClient = new RpcClient();
         this.configRpcClient(rpcClient);
         this.rpcClient.init();
-        this.rpcExecutor = ThreadPoolUtil.newThreadPool("JRaft-RPC-Processor", true, rpcProcessorThreadPoolSize / 3,
-            rpcProcessorThreadPoolSize, 60L, new ArrayBlockingQueue<>(10000), new NamedThreadFactory(
-                "JRaft-RPC-Processor-"));
+        this.rpcExecutor = ThreadPoolUtil.newBuilder() //
+            .poolName("JRaft-RPC-Processor") //
+            .enableMetric(true) //
+            .coreThreads(rpcProcessorThreadPoolSize / 3) //
+            .maximumThreads(rpcProcessorThreadPoolSize) //
+            .keepAliveSeconds(60L) //
+            .workQueue(new ArrayBlockingQueue<>(10000)) //
+            .threadFactory(new NamedThreadFactory("JRaft-RPC-Processor-")) //
+            .build();
         if (this.rpcOptions.getMetricRegistry() != null) {
             this.rpcOptions.getMetricRegistry().register("raft-rpc-client-thread-pool",
                 new ThreadPoolMetricSet(this.rpcExecutor));

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadPoolUtil.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadPoolUtil.java
@@ -33,6 +33,10 @@ public final class ThreadPoolUtil {
      */
     private static final RejectedExecutionHandler defaultHandler = new ThreadPoolExecutor.AbortPolicy();
 
+    public static PoolBuilder newBuilder() {
+        return new PoolBuilder();
+    }
+
     /**
      * Creates a new {@code MetricThreadPoolExecutor} or {@code LogThreadPoolExecutor}
      * with the given initial parameters and default rejected execution handler.
@@ -109,5 +113,70 @@ public final class ThreadPoolUtil {
     }
 
     private ThreadPoolUtil() {
+    }
+
+    public static class PoolBuilder {
+        private String                   poolName;
+        private Boolean                  enableMetric;
+        private Integer                  coreThreads;
+        private Integer                  maximumThreads;
+        private Long                     keepAliveSeconds;
+        private BlockingQueue<Runnable>  workQueue;
+        private ThreadFactory            threadFactory;
+        private RejectedExecutionHandler handler = ThreadPoolUtil.defaultHandler;
+
+        public PoolBuilder poolName(final String poolName) {
+            this.poolName = poolName;
+            return this;
+        }
+
+        public PoolBuilder enableMetric(final Boolean enableMetric) {
+            this.enableMetric = enableMetric;
+            return this;
+        }
+
+        public PoolBuilder coreThreads(final Integer coreThreads) {
+            this.coreThreads = coreThreads;
+            return this;
+        }
+
+        public PoolBuilder maximumThreads(final Integer maximumThreads) {
+            this.maximumThreads = maximumThreads;
+            return this;
+        }
+
+        public PoolBuilder keepAliveSeconds(final Long keepAliveSeconds) {
+            this.keepAliveSeconds = keepAliveSeconds;
+            return this;
+        }
+
+        public PoolBuilder workQueue(final BlockingQueue<Runnable> workQueue) {
+            this.workQueue = workQueue;
+            return this;
+        }
+
+        public PoolBuilder threadFactory(final ThreadFactory threadFactory) {
+            this.threadFactory = threadFactory;
+            return this;
+        }
+
+        public PoolBuilder rejectedHandler(final RejectedExecutionHandler handler) {
+            this.handler = handler;
+            return this;
+        }
+
+        public ThreadPoolExecutor build() {
+            Requires.requireNonNull(this.poolName, "poolName");
+            Requires.requireNonNull(this.enableMetric, "enableMetric");
+            Requires.requireNonNull(this.coreThreads, "coreThreads");
+            Requires.requireNonNull(this.maximumThreads, "maximumThreads");
+            Requires.requireNonNull(this.keepAliveSeconds, "keepAliveSeconds");
+            Requires.requireNonNull(this.workQueue, "workQueue");
+            Requires.requireNonNull(this.threadFactory, "threadFactory");
+            Requires.requireNonNull(this.handler, "handler");
+
+            return ThreadPoolUtil.newThreadPool(this.poolName, this.enableMetric, this.coreThreads,
+                this.maximumThreads, this.keepAliveSeconds, this.workQueue, this.threadFactory, this.handler);
+        }
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -69,7 +69,7 @@ public class Utils {
      */
     private static ThreadPoolExecutor CLOSURE_EXECUTOR               = ThreadPoolUtil
                                                                          .newBuilder()
-                                                                         .poolName("CLOSURE_EXECUTOR")
+                                                                         .poolName("JRAFT_CLOSURE_EXECUTOR")
                                                                          .enableMetric(true)
                                                                          .coreThreads(MIN_CLOSURE_EXECUTOR_POOL_SIZE)
                                                                          .maximumThreads(MAX_CLOSURE_EXECUTOR_POOL_SIZE)

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -67,12 +67,18 @@ public class Utils {
     /**
      * Global thread pool to run closure.
      */
-    private static ThreadPoolExecutor CLOSURE_EXECUTOR               = ThreadPoolUtil.newThreadPool("CLOSURE_EXECUTOR",
-                                                                         true, MIN_CLOSURE_EXECUTOR_POOL_SIZE,
-                                                                         MAX_CLOSURE_EXECUTOR_POOL_SIZE, 60L,
-                                                                         new SynchronousQueue<>(),
-                                                                         new NamedThreadFactory(
-                                                                             "JRaft-Closure-Executor-", true));
+    private static ThreadPoolExecutor CLOSURE_EXECUTOR               = ThreadPoolUtil
+                                                                         .newBuilder()
+                                                                         .poolName("CLOSURE_EXECUTOR")
+                                                                         .enableMetric(true)
+                                                                         .coreThreads(MIN_CLOSURE_EXECUTOR_POOL_SIZE)
+                                                                         .maximumThreads(MAX_CLOSURE_EXECUTOR_POOL_SIZE)
+                                                                         .keepAliveSeconds(60L)
+                                                                         .workQueue(new SynchronousQueue<>())
+                                                                         .threadFactory(
+                                                                             new NamedThreadFactory(
+                                                                                 "JRaft-Closure-Executor-", true))
+                                                                         .build();
 
     private static final Pattern      GROUP_ID_PATTER                = Pattern.compile("^[a-zA-Z][a-zA-Z0-9\\-_]*$");
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import com.alipay.remoting.rpc.RpcServer;
@@ -131,9 +130,16 @@ public final class StoreEngineHelper {
     private static ExecutorService newPool(final int coreThreads, final int maxThreads,
                                            final BlockingQueue<Runnable> workQueue, final String name,
                                            final RejectedExecutionHandler handler) {
-        final ThreadFactory defaultFactory = new NamedThreadFactory(name, true);
-        return ThreadPoolUtil.newThreadPool(name, true, coreThreads, maxThreads, 60L, workQueue, defaultFactory,
-            handler);
+        return ThreadPoolUtil.newBuilder() //
+            .poolName(name) //
+            .enableMetric(true) //
+            .coreThreads(coreThreads) //
+            .maximumThreads(maxThreads) //
+            .keepAliveSeconds(60L) //
+            .workQueue(workQueue) //
+            .threadFactory(new NamedThreadFactory(name, true)) //
+            .rejectedHandler(handler) //
+            .build();
     }
 
     private StoreEngineHelper() {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
@@ -56,38 +56,38 @@ public final class StoreEngineHelper {
     public static ExecutorService createReadIndexExecutor(final int coreThreads) {
         final int maxThreads = coreThreads << 2;
         final RejectedExecutionHandler handler = new ThreadPoolExecutor.AbortPolicy();
-        return newPool(coreThreads, maxThreads, "read-index-callback", handler);
+        return newPool(coreThreads, maxThreads, "rheakv-read-index-callback", handler);
     }
 
     public static ExecutorService createLeaderStateTrigger(final int coreThreads) {
         final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(32);
-        return newPool(coreThreads, coreThreads, "leader-state-trigger", workQueue);
+        return newPool(coreThreads, coreThreads, "rheakv-leader-state-trigger", workQueue);
     }
 
     public static ExecutorService createSnapshotExecutor(final int coreThreads) {
         final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(1);
-        final String name = "snapshot-executor";
+        final String name = "rheakv-snapshot-executor";
         final RejectedExecutionHandler handler = new DiscardOldPolicyWithReport(name);
         return newPool(coreThreads, coreThreads, workQueue, name, handler);
     }
 
     public static ExecutorService createCliRpcExecutor(final int coreThreads) {
         final int maxThreads = coreThreads << 2;
-        return newPool(coreThreads, maxThreads, "cli-rpc-executor");
+        return newPool(coreThreads, maxThreads, "rheakv-cli-rpc-executor");
     }
 
     public static ExecutorService createRaftRpcExecutor(final int coreThreads) {
         final int maxThreads = coreThreads << 1;
-        return newPool(coreThreads, maxThreads, "raft-rpc-executor");
+        return newPool(coreThreads, maxThreads, "rheakv-raft-rpc-executor");
     }
 
     public static ExecutorService createKvRpcExecutor(final int coreThreads) {
         final int maxThreads = coreThreads << 2;
-        return newPool(coreThreads, maxThreads, "kv-store-rpc-executor");
+        return newPool(coreThreads, maxThreads, "rheakv-kv-store-rpc-executor");
     }
 
     public static ScheduledExecutorService createMetricsScheduler() {
-        return Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("metrics-reporter", true));
+        return Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("rheakv-metrics-reporter", true));
     }
 
     public static void addKvStoreRequestProcessor(final RpcServer rpcServer, final StoreEngine engine) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVRpcService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVRpcService.java
@@ -73,8 +73,7 @@ public class DefaultRheaKVRpcService implements RheaKVRpcService {
             LOG.info("[DefaultRheaKVRpcService] already started.");
             return true;
         }
-        this.rpcCallbackExecutor = createRpcCallbackExecutor(opts.getCallbackExecutorCorePoolSize(),
-            opts.getCallbackExecutorMaximumPoolSize(), opts.getCallbackExecutorQueueCapacity());
+        this.rpcCallbackExecutor = createRpcCallbackExecutor(opts);
         this.rpcTimeoutMillis = opts.getRpcTimeoutMillis();
         Requires.requireTrue(this.rpcTimeoutMillis > 0, "opts.rpcTimeoutMillis must > 0");
         LOG.info("[DefaultRheaKVRpcService] start successfully, options: {}.", opts);
@@ -166,13 +165,23 @@ public class DefaultRheaKVRpcService implements RheaKVRpcService {
         }
     }
 
-    private ThreadPoolExecutor createRpcCallbackExecutor(final int corePoolSize, final int maximumPoolSize,
-                                                         final int queueCapacity) {
-        if (corePoolSize <= 0 || maximumPoolSize <= 0) {
+    private ThreadPoolExecutor createRpcCallbackExecutor(final RpcOptions opts) {
+        final int callbackExecutorCorePoolSize = opts.getCallbackExecutorCorePoolSize();
+        final int callbackExecutorMaximumPoolSize = opts.getCallbackExecutorMaximumPoolSize();
+        if (callbackExecutorCorePoolSize <= 0 || callbackExecutorMaximumPoolSize <= 0) {
             return null;
         }
+
         final String name = "rpc-callback";
-        return ThreadPoolUtil.newThreadPool(name, true, corePoolSize, maximumPoolSize, 120L, new ArrayBlockingQueue<>(
-            queueCapacity), new NamedThreadFactory(name, true), new CallerRunsPolicyWithReport(name));
+        return ThreadPoolUtil.newBuilder() //
+            .poolName(name) //
+            .enableMetric(true) //
+            .coreThreads(callbackExecutorCorePoolSize) //
+            .maximumThreads(callbackExecutorMaximumPoolSize) //
+            .keepAliveSeconds(120L) //
+            .workQueue(new ArrayBlockingQueue<>(opts.getCallbackExecutorQueueCapacity())) //
+            .threadFactory(new NamedThreadFactory(name, true)) //
+            .rejectedHandler(new CallerRunsPolicyWithReport(name)) //
+            .build();
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVRpcService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVRpcService.java
@@ -172,7 +172,7 @@ public class DefaultRheaKVRpcService implements RheaKVRpcService {
             return null;
         }
 
-        final String name = "rpc-callback";
+        final String name = "rheakv-rpc-callback";
         return ThreadPoolUtil.newBuilder() //
             .poolName(name) //
             .enableMetric(true) //

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/DefaultPlacementDriverRpcService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/DefaultPlacementDriverRpcService.java
@@ -133,7 +133,7 @@ public class DefaultPlacementDriverRpcService implements PlacementDriverRpcServi
             return null;
         }
 
-        final String name = "pd-rpc-callback";
+        final String name = "rheakv-pd-rpc-callback";
         return ThreadPoolUtil.newBuilder() //
             .poolName(name) //
             .enableMetric(true) //

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/DefaultPlacementDriverRpcService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/DefaultPlacementDriverRpcService.java
@@ -68,8 +68,7 @@ public class DefaultPlacementDriverRpcService implements PlacementDriverRpcServi
             LOG.info("[DefaultPlacementDriverRpcService] already started.");
             return true;
         }
-        this.rpcCallbackExecutor = createRpcCallbackExecutor(opts.getCallbackExecutorCorePoolSize(),
-            opts.getCallbackExecutorMaximumPoolSize(), opts.getCallbackExecutorQueueCapacity());
+        this.rpcCallbackExecutor = createRpcCallbackExecutor(opts);
         this.rpcTimeoutMillis = opts.getRpcTimeoutMillis();
         Requires.requireTrue(this.rpcTimeoutMillis > 0, "opts.rpcTimeoutMillis must > 0");
         LOG.info("[DefaultPlacementDriverRpcService] start successfully, options: {}.", opts);
@@ -127,13 +126,23 @@ public class DefaultPlacementDriverRpcService implements PlacementDriverRpcServi
         }
     }
 
-    private ThreadPoolExecutor createRpcCallbackExecutor(final int corePoolSize, final int maximumPoolSize,
-                                                         final int queueCapacity) {
-        if (corePoolSize <= 0 || maximumPoolSize <= 0) {
+    private ThreadPoolExecutor createRpcCallbackExecutor(final RpcOptions opts) {
+        final int callbackExecutorCorePoolSize = opts.getCallbackExecutorCorePoolSize();
+        final int callbackExecutorMaximumPoolSize = opts.getCallbackExecutorMaximumPoolSize();
+        if (callbackExecutorCorePoolSize <= 0 || callbackExecutorMaximumPoolSize <= 0) {
             return null;
         }
+
         final String name = "pd-rpc-callback";
-        return ThreadPoolUtil.newThreadPool(name, true, corePoolSize, maximumPoolSize, 120L, new ArrayBlockingQueue<>(
-            queueCapacity), new NamedThreadFactory(name, true), new CallerRunsPolicyWithReport(name));
+        return ThreadPoolUtil.newBuilder() //
+            .poolName(name) //
+            .enableMetric(true) //
+            .coreThreads(callbackExecutorCorePoolSize) //
+            .maximumThreads(callbackExecutorMaximumPoolSize) //
+            .keepAliveSeconds(120L) //
+            .workQueue(new ArrayBlockingQueue<>(opts.getCallbackExecutorQueueCapacity())) //
+            .threadFactory(new NamedThreadFactory(name, true)) //
+            .rejectedHandler(new CallerRunsPolicyWithReport(name)) //
+            .build();
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/HeartbeatSender.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/HeartbeatSender.java
@@ -97,7 +97,7 @@ public class HeartbeatSender implements Lifecycle<HeartbeatOptions> {
             throw new IllegalArgumentException("Heartbeat rpc timeout millis must > 0, "
                                                + this.heartbeatRpcTimeoutMillis);
         }
-        final String name = "heartbeat-callback";
+        final String name = "rheakv-heartbeat-callback";
         this.heartbeatRpcCallbackExecutor = ThreadPoolUtil.newBuilder() //
             .poolName(name) //
             .enableMetric(true) //

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/HeartbeatSender.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/HeartbeatSender.java
@@ -98,8 +98,16 @@ public class HeartbeatSender implements Lifecycle<HeartbeatOptions> {
                                                + this.heartbeatRpcTimeoutMillis);
         }
         final String name = "heartbeat-callback";
-        this.heartbeatRpcCallbackExecutor = ThreadPoolUtil.newThreadPool(name, true, 4, 4, 120L,
-            new ArrayBlockingQueue<>(1024), new NamedThreadFactory(name, true), new DiscardOldPolicyWithReport(name));
+        this.heartbeatRpcCallbackExecutor = ThreadPoolUtil.newBuilder() //
+            .poolName(name) //
+            .enableMetric(true) //
+            .coreThreads(4) //
+            .maximumThreads(4) //
+            .keepAliveSeconds(120L) //
+            .workQueue(new ArrayBlockingQueue<>(1024)) //
+            .threadFactory(new NamedThreadFactory(name, true)) //
+            .rejectedHandler(new DiscardOldPolicyWithReport(name)) //
+            .build();
         final long storeHeartbeatIntervalSeconds = opts.getStoreHeartbeatIntervalSeconds();
         final long regionHeartbeatIntervalSeconds = opts.getRegionHeartbeatIntervalSeconds();
         if (storeHeartbeatIntervalSeconds <= 0) {

--- a/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/DefaultPlacementDriverService.java
+++ b/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/DefaultPlacementDriverService.java
@@ -331,7 +331,7 @@ public class DefaultPlacementDriverService implements PlacementDriverService, Le
             return null;
         }
 
-        final String name = "pipeline-executor";
+        final String name = "rheakv-pipeline-executor";
         return ThreadPoolUtil.newBuilder() //
             .poolName(name) //
             .enableMetric(false) //

--- a/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/DefaultPlacementDriverService.java
+++ b/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/DefaultPlacementDriverService.java
@@ -96,13 +96,8 @@ public class DefaultPlacementDriverService implements PlacementDriverService, Le
         }
         Requires.requireNonNull(opts, "placementDriverServerOptions");
         this.metadataStore = new DefaultMetadataStore(this.rheaKVStore);
-        final int corePoolSize = opts.getPipelineCorePoolSize();
-        final int maximumPoolSize = opts.getPipelineMaximumPoolSize();
-        if (corePoolSize > 0 && maximumPoolSize > 0) {
-            final String name = "pipeline-executor";
-            final ThreadPoolExecutor threadPool = ThreadPoolUtil.newThreadPool(name, false, corePoolSize,
-                maximumPoolSize, 120L, new ArrayBlockingQueue<>(1024), new NamedThreadFactory(name, true),
-                new CallerRunsPolicyWithReport(name));
+        final ThreadPoolExecutor threadPool = createPipelineExecutor(opts);
+        if (threadPool != null) {
             this.pipelineInvoker = new DefaultHandlerInvoker(threadPool);
         }
         this.pipeline = new DefaultPipeline() //
@@ -327,5 +322,25 @@ public class DefaultPlacementDriverService implements PlacementDriverService, Le
             this.metadataStore.invalidCache();
         }
         ClusterStatsManager.invalidCache();
+    }
+
+    private ThreadPoolExecutor createPipelineExecutor(final PlacementDriverServerOptions opts) {
+        final int corePoolSize = opts.getPipelineCorePoolSize();
+        final int maximumPoolSize = opts.getPipelineMaximumPoolSize();
+        if (corePoolSize <= 0 || maximumPoolSize <= 0) {
+            return null;
+        }
+
+        final String name = "pipeline-executor";
+        return ThreadPoolUtil.newBuilder() //
+            .poolName(name) //
+            .enableMetric(false) //
+            .coreThreads(corePoolSize) //
+            .maximumThreads(maximumPoolSize) //
+            .keepAliveSeconds(120L) //
+            .workQueue(new ArrayBlockingQueue<>(1024)) //
+            .threadFactory(new NamedThreadFactory(name, true)) //
+            .rejectedHandler(new CallerRunsPolicyWithReport(name)) //
+            .build();
     }
 }

--- a/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/PlacementDriverServer.java
+++ b/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/PlacementDriverServer.java
@@ -18,9 +18,6 @@ package com.alipay.sofa.jraft.rhea;
 
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.slf4j.Logger;
@@ -222,12 +219,16 @@ public class PlacementDriverServer implements Lifecycle<PlacementDriverServerOpt
 
     private ThreadPoolExecutor createDefaultPdExecutor() {
         final int corePoolSize = Math.max(Constants.AVAILABLE_PROCESSORS << 2, 32);
-        final int maximumPoolSize = corePoolSize << 2;
-        final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(4096);
         final String name = "pd-executor";
-        final ThreadFactory threadFactory = new NamedThreadFactory(name, true);
-        final RejectedExecutionHandler handler = new CallerRunsPolicyWithReport(name, name);
-        return ThreadPoolUtil.newThreadPool(name, true, corePoolSize, maximumPoolSize, 120L, workQueue, threadFactory,
-            handler);
+        return ThreadPoolUtil.newBuilder() //
+            .poolName(name) //
+            .enableMetric(true) //
+            .coreThreads(corePoolSize) //
+            .maximumThreads(corePoolSize << 2) //
+            .keepAliveSeconds(120L) //
+            .workQueue(new ArrayBlockingQueue<>(4096)) //
+            .threadFactory(new NamedThreadFactory(name, true)) //
+            .rejectedHandler(new CallerRunsPolicyWithReport(name, name)) //
+            .build();
     }
 }

--- a/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/PlacementDriverServer.java
+++ b/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/PlacementDriverServer.java
@@ -219,7 +219,7 @@ public class PlacementDriverServer implements Lifecycle<PlacementDriverServerOpt
 
     private ThreadPoolExecutor createDefaultPdExecutor() {
         final int corePoolSize = Math.max(Constants.AVAILABLE_PROCESSORS << 2, 32);
-        final String name = "pd-executor";
+        final String name = "rheakv-pd-executor";
         return ThreadPoolUtil.newBuilder() //
             .poolName(name) //
             .enableMetric(true) //


### PR DESCRIPTION
### Motivation:

The methods parameters in ThreadPoolUtil are too many, which makes the code really ugly.

### Modification:

Add a PoolBuilder

```
ThreadPoolUtil.newBuilder() //
            .poolName(name) //
            .enableMetric(false) //
            .coreThreads(corePoolSize) //
            .maximumThreads(maximumPoolSize) //
            .keepAliveSeconds(120L) //
            .workQueue(new ArrayBlockingQueue<>(1024)) //
            .threadFactory(new NamedThreadFactory(name, true)) //
            .rejectedHandler(new CallerRunsPolicyWithReport(name)) //
            .build();
```

### Result:

The code is no longer ugly

