### PR TITLE
Fix an serve bug of RepeatedTimer

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
@@ -182,7 +182,7 @@ public abstract class RepeatedTimer {
                 schedule();
             }
         } finally {
-            lock.lock();
+            lock.unlock();
         }
     }
 
@@ -194,7 +194,7 @@ public abstract class RepeatedTimer {
         try {
             this.reset(this.timeoutMs);
         } finally {
-            lock.lock();
+            lock.unlock();
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
@@ -259,4 +259,5 @@ public abstract class RepeatedTimer {
         }
     }
 
+
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
@@ -259,5 +259,4 @@ public abstract class RepeatedTimer {
         }
     }
 
-
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RepeatedTimerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RepeatedTimerTest.java
@@ -115,4 +115,21 @@ public class RepeatedTimerTest {
         Thread.sleep(1000);
         assertEquals(10, timer.counter.get(), 3);
     }
+
+    @Test
+    public void testReset()throws Exception {
+        this.timer.start();
+        assertEquals(50, timer.getTimeoutMs());
+        for(int i = 0; i < 10; i++){
+            Thread.sleep(80);
+            this.timer.reset();
+        }
+        assertEquals(10, timer.counter.get(), 3);
+        this.timer.reset(100);
+        for(int i =0 ; i < 10 ; i++){
+            Thread.sleep(80);
+            this.timer.reset();
+        }
+        assertEquals(10, timer.counter.get(), 3);
+    }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RepeatedTimerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RepeatedTimerTest.java
@@ -117,16 +117,16 @@ public class RepeatedTimerTest {
     }
 
     @Test
-    public void testReset()throws Exception {
+    public void testReset() throws Exception {
         this.timer.start();
         assertEquals(50, timer.getTimeoutMs());
-        for(int i = 0; i < 10; i++){
+        for (int i = 0; i < 10; i++) {
             Thread.sleep(80);
             this.timer.reset();
         }
         assertEquals(10, timer.counter.get(), 3);
         this.timer.reset(100);
-        for(int i =0 ; i < 10 ; i++){
+        for (int i = 0; i < 10; i++) {
             Thread.sleep(80);
             this.timer.reset();
         }


### PR DESCRIPTION
### Motivation:
When I used your `reset()` method of abstract class `RepeatedTimer`, I found a tiny but fatal bug.

### Modification:
Change `lock.lock()` in finally block to `lock.unlock()`.

### Result:
It just two lines code, but it's fatal. So I want to remind you.
