### PR TITLE
(feat) add direct ByteBuffer support

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/Serializer.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/Serializer.java
@@ -16,6 +16,8 @@
  */
 package com.alipay.sofa.jraft.rhea.serialization;
 
+import java.nio.ByteBuffer;
+
 import com.alipay.sofa.jraft.rhea.serialization.io.InputBuf;
 import com.alipay.sofa.jraft.rhea.serialization.io.OutputBuf;
 
@@ -41,6 +43,8 @@ public abstract class Serializer {
     public abstract <T> byte[] writeObject(final T obj);
 
     public abstract <T> T readObject(final InputBuf inputBuf, final Class<T> clazz);
+
+    public abstract <T> T readObject(final ByteBuffer buf, final Class<T> clazz);
 
     public abstract <T> T readObject(final byte[] bytes, final int offset, final int length, final Class<T> clazz);
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/ProtoStuffSerializer.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/ProtoStuffSerializer.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.jraft.rhea.serialization.impl.protostuff;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import io.protostuff.Input;
 import io.protostuff.LinkedBuffer;
@@ -110,6 +111,22 @@ public class ProtoStuffSerializer extends Serializer {
             ThrowUtil.throwException(e);
         } finally {
             inputBuf.release();
+        }
+
+        return msg;
+    }
+
+    @Override
+    public <T> T readObject(final ByteBuffer buf, final Class<T> clazz) {
+        final Schema<T> schema = RuntimeSchema.getSchema(clazz);
+        final T msg = schema.newMessage();
+
+        final Input input = Inputs.getInput(buf);
+        try {
+            schema.mergeFrom(input, msg);
+            Inputs.checkLastTagWas(input, 0);
+        } catch (final IOException e) {
+            ThrowUtil.throwException(e);
         }
 
         return msg;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/Inputs.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/Inputs.java
@@ -16,6 +16,8 @@
  */
 package com.alipay.sofa.jraft.rhea.serialization.impl.protostuff.io;
 
+import java.nio.ByteBuffer;
+
 import io.protostuff.ByteArrayInput;
 import io.protostuff.Input;
 import io.protostuff.ProtobufException;
@@ -34,6 +36,13 @@ public final class Inputs {
             return new UnsafeNioBufInput(inputBuf.nioByteBuffer(), true);
         }
         return new NioBufInput(inputBuf.nioByteBuffer(), true);
+    }
+
+    public static Input getInput(final ByteBuffer buf) {
+        if (UnsafeUtil.hasUnsafe() && buf.isDirect()) {
+            return new UnsafeNioBufInput(buf, true);
+        }
+        return new NioBufInput(buf, true);
     }
 
     public static Input getInput(final byte[] bytes, final int offset, final int length) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.jraft.rhea.storage;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -87,9 +88,13 @@ public class KVStoreStateMachine extends StateMachineAdapter {
             if (done != null) {
                 kvOp = done.getOperation();
             } else {
-                final byte[] data = it.getData().array();
+                final ByteBuffer buf = it.getData();
                 try {
-                    kvOp = this.serializer.readObject(data, KVOperation.class);
+                    if (buf.hasArray()) {
+                        kvOp = this.serializer.readObject(buf.array(), KVOperation.class);
+                    } else {
+                        kvOp = this.serializer.readObject(buf, KVOperation.class);
+                    }
                 } catch (final Throwable t) {
                     throw new StoreCodecException("Decode operation error", t);
                 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/serialization/SerializerTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/serialization/SerializerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.serialization;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.rhea.storage.KVOperation;
+import com.alipay.sofa.jraft.util.BytesUtil;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author jiachun.fjc
+ */
+public class SerializerTest {
+
+    @Test
+    public void readObjectTest() {
+        final Serializer serializer = Serializers.getDefault();
+        final KVOperation op = KVOperation.createPut(BytesUtil.writeUtf8("key"), BytesUtil.writeUtf8("value"));
+        final byte[] bytes = serializer.writeObject(op);
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(bytes.length);
+        buffer.put(bytes);
+        buffer.flip();
+
+        final KVOperation op1 = serializer.readObject(bytes, KVOperation.class);
+        final KVOperation op2 = serializer.readObject(buffer, KVOperation.class);
+
+        assertArrayEquals(op1.getKey(), op.getKey());
+        assertArrayEquals(op1.getValue(), op.getValue());
+        assertEquals(op.getOp(), op.getOp());
+
+        assertArrayEquals(op1.getKey(), op2.getKey());
+        assertArrayEquals(op1.getValue(), op2.getValue());
+        assertEquals(op.getOp(), op2.getOp());
+    }
+}


### PR DESCRIPTION
### Motivation:

Now jraft uses HeadByteBuffer, but one day it might use DirectByteBuffer. KVStoreStateMachine should support DirectByteBuffer data parsing

### Modification:

### Result:

