### PR TITLE
(feat) Refused requests when node is overload, #138

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -24,6 +24,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -686,7 +686,7 @@ public class FSMCallerImpl implements FSMCaller {
             this.fsm.onError(e);
         }
         if (this.node != null) {
-            Utils.runInThread(() -> this.node.onError(e));
+            this.node.onError(e);
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -47,16 +47,19 @@ import com.alipay.sofa.jraft.option.FSMCallerOptions;
 import com.alipay.sofa.jraft.storage.LogManager;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter;
+import com.alipay.sofa.jraft.util.DisruptorBuilder;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.OnlyForTest;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.Utils;
+import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.EventTranslator;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
 
 /**
  * The finite state machine caller implementation.
@@ -153,7 +156,7 @@ public class FSMCallerImpl implements FSMCaller {
     private NodeImpl                                                node;
     private volatile TaskType                                       currTask;
     private final AtomicLong                                        applyingIndex;
-    private RaftException                                           error;
+    private volatile RaftException                                  error;
     private Disruptor<ApplyTask>                                    disruptor;
     private RingBuffer<ApplyTask>                                   taskQueue;
     private volatile CountDownLatch                                 shutdownLatch;
@@ -178,8 +181,13 @@ public class FSMCallerImpl implements FSMCaller {
         this.lastAppliedIndex.set(opts.getBootstrapId().getIndex());
         notifyLastAppliedIndexUpdated(this.lastAppliedIndex.get());
         this.lastAppliedTerm = opts.getBootstrapId().getTerm();
-        this.disruptor = new Disruptor<>(new ApplyTaskFactory(), opts.getDisruptorBufferSize(), new NamedThreadFactory(
-            "JRaft-FSMCaller-disruptor-", true));
+        this.disruptor = DisruptorBuilder.<ApplyTask> newInstance() //
+            .setEventFactory(new ApplyTaskFactory()) //
+            .setRingBufferSize(opts.getDisruptorBufferSize()) //
+            .setThreadFactory(new NamedThreadFactory("JRaft-FSMCaller-disruptor-", true)) //
+            .setProducerType(ProducerType.MULTI) //
+            .setWaitStrategy(new BlockingWaitStrategy()) //
+            .build();
         this.disruptor.handleEventsWith(new ApplyTaskHandler());
         this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(getClass().getSimpleName()));
         this.disruptor.start();
@@ -321,6 +329,10 @@ public class FSMCallerImpl implements FSMCaller {
 
     @Override
     public boolean onError(final RaftException error) {
+        if (!this.error.getStatus().isOk()) {
+            LOG.warn("FSMCaller already in error status, ignore new error: {}", error);
+            return false;
+        }
         final OnErrorClosure c = new OnErrorClosure(error);
         return enqueueTask((task, sequence) -> {
             task.type = TaskType.ERROR;
@@ -674,7 +686,7 @@ public class FSMCallerImpl implements FSMCaller {
             this.fsm.onError(e);
         }
         if (this.node != null) {
-            this.node.onError(e);
+            Utils.runInThread(() -> this.node.onError(e));
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -102,6 +102,7 @@ import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.OnlyForTest;
 import com.alipay.sofa.jraft.util.RepeatedTimer;
 import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.ThreadHelper;
 import com.alipay.sofa.jraft.util.ThreadId;
 import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.Message;
@@ -1324,8 +1325,7 @@ public class NodeImpl implements Node, RaftServerService {
                         this.metrics.recordTimes("apply-task-overload-times", 1);
                         return;
                     }
-                    //TODO use Thread.onSpinWait instead in JDK9
-                    Thread.yield();
+                    ThreadHelper.onSpinWait();
                 }
             }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeMetrics.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeMetrics.java
@@ -32,7 +32,7 @@ public class NodeMetrics {
 
     private final MetricRegistry metrics;
 
-    public NodeMetrics(boolean enableMetrics) {
+    public NodeMetrics(final boolean enableMetrics) {
         if (enableMetrics) {
             this.metrics = new MetricRegistry();
         } else {
@@ -59,6 +59,17 @@ public class NodeMetrics {
      */
     public MetricRegistry getMetricRegistry() {
         return this.metrics;
+    }
+
+    /**
+     * Recored operation times.
+     * @param key
+     * @param times
+     */
+    public void recordTimes(final String key, final long times) {
+        if (this.metrics != null) {
+            this.metrics.counter(key).inc(times);
+        }
     }
 
     /**

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeMetrics.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeMetrics.java
@@ -62,7 +62,7 @@ public class NodeMetrics {
     }
 
     /**
-     * Recored operation times.
+     * Records operation times.
      * @param key
      * @param times
      */
@@ -73,7 +73,7 @@ public class NodeMetrics {
     }
 
     /**
-     * Recorded operation batch size.
+     * Records operation batch size.
      *
      * @param key  key of operation
      * @param size size of operation
@@ -85,7 +85,7 @@ public class NodeMetrics {
     }
 
     /**
-     * Record operation latency.
+     * Records operation latency.
      *
      * @param key      key of operation
      * @param duration duration of operation

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -220,8 +220,8 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                 .setEventFactory(new ReadIndexEventFactory()) //
                 .setRingBufferSize(this.raftOptions.getDisruptorBufferSize()) //
                 .setThreadFactory(new NamedThreadFactory("JRaft-ReadOnlyService-Disruptor-", true)) //
-            .setWaitStrategy(new BlockingWaitStrategy()) //
-            .setProducerType(ProducerType.MULTI) //
+                .setWaitStrategy(new BlockingWaitStrategy()) //
+                .setProducerType(ProducerType.MULTI) //
                 .build();
         this.readIndexDisruptor.handleEventsWith(new ReadIndexEventHandler());
         this.readIndexDisruptor

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -49,6 +49,7 @@ import com.alipay.sofa.jraft.util.DisruptorBuilder;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.OnlyForTest;
+import com.alipay.sofa.jraft.util.ThreadHelper;
 import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.ZeroByteStringHelper;
 import com.lmax.disruptor.BlockingWaitStrategy;
@@ -214,7 +215,6 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
         this.node.handleReadIndexRequest(request, new ReadIndexResponseClosure(states, request));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public boolean init(final ReadOnlyServiceOptions opts) {
         this.node = opts.getNode();
@@ -290,8 +290,7 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                         LOG.warn("Node {} ReadOnlyServiceImpl readIndexQueue is overload.", this.node.getNodeId());
                         return;
                     }
-                    //TODO use Thread.onSpinWait instead in jdk9
-                    Thread.yield();
+                    ThreadHelper.onSpinWait();
                 }
             }
         } catch (final Exception e) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -26,37 +26,42 @@ package com.alipay.sofa.jraft.option;
 public class RaftOptions {
 
     /** Maximum of block size per RPC */
-    private int            maxByteCountPerRpc        = 128 * 1024;
+    private int            maxByteCountPerRpc                   = 128 * 1024;
     /** File service check hole switch, default disable */
-    private boolean        fileCheckHole             = false;
+    private boolean        fileCheckHole                        = false;
     /** The maximum number of entries in AppendEntriesRequest */
-    private int            maxEntriesSize            = 1024;
+    private int            maxEntriesSize                       = 1024;
     /** The maximum byte size of AppendEntriesRequest */
-    private int            maxBodySize               = 512 * 1024;
+    private int            maxBodySize                          = 512 * 1024;
     /** Flush buffer to LogStorage if the buffer size reaches the limit */
-    private int            maxAppendBufferSize       = 256 * 1024;
+    private int            maxAppendBufferSize                  = 256 * 1024;
     /** Maximum election delay time allowed by user */
-    private int            maxElectionDelayMs        = 1000;
+    private int            maxElectionDelayMs                   = 1000;
     /** Raft election:heartbeat timeout factor */
-    private int            electionHeartbeatFactor   = 10;
+    private int            electionHeartbeatFactor              = 10;
     /** Maximum number of tasks that can be applied in a batch */
-    private int            applyBatch                = 32;
+    private int            applyBatch                           = 32;
     /** Call fsync when need */
-    private boolean        sync                      = true;
+    private boolean        sync                                 = true;
     /** Sync log meta, snapshot meta and raft meta */
-    private boolean        syncMeta                  = false;
+    private boolean        syncMeta                             = false;
     /** Whether to enable replicator pipeline. */
-    private boolean        replicatorPipeline        = true;
+    private boolean        replicatorPipeline                   = true;
     /** The maximum replicator pipeline in-flight requests/responses, only valid when enable replicator pipeline. */
-    private int            maxReplicatorInflightMsgs = 256;
+    private int            maxReplicatorInflightMsgs            = 256;
     /** Internal disruptor buffers size for Node/FSMCaller/LogManager etc. */
-    private int            disruptorBufferSize       = 16384;
+    private int            disruptorBufferSize                  = 16384;
+    /**
+     * The maximum timeout in seconds to wait when publishing events into disruptor, default is 10 seconds.
+     * If the timeout happens, it may halt the node.
+     * */
+    private int            disruptorPublishEventWaitTimeoutSecs = 10;
     /**
      *  When true, validate log entry checksum when transferring the log entry from disk or network, default is false.
      *  If true, it would hurt the performance of JRAft but gain the data safety.
      *  @since 1.2.6
      */
-    private boolean        enableLogEntryChecksum    = false;
+    private boolean        enableLogEntryChecksum               = false;
 
     /**
      * ReadOnlyOption specifies how the read only request is processed.
@@ -70,7 +75,15 @@ public class RaftOptions {
      * should (clock can move backward/pause without any bound). ReadIndex is not safe
      * in that case.
      */
-    private ReadOnlyOption readOnlyOptions           = ReadOnlyOption.ReadOnlySafe;
+    private ReadOnlyOption readOnlyOptions                      = ReadOnlyOption.ReadOnlySafe;
+
+    public int getDisruptorPublishEventWaitTimeoutSecs() {
+        return this.disruptorPublishEventWaitTimeoutSecs;
+    }
+
+    public void setDisruptorPublishEventWaitTimeoutSecs(final int disruptorPublishEventWaitTimeoutSecs) {
+        this.disruptorPublishEventWaitTimeoutSecs = disruptorPublishEventWaitTimeoutSecs;
+    }
 
     public boolean isEnableLogEntryChecksum() {
         return this.enableLogEntryChecksum;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -55,6 +55,7 @@ import com.alipay.sofa.jraft.util.DisruptorBuilder;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.ThreadHelper;
 import com.alipay.sofa.jraft.util.Utils;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
@@ -342,8 +343,7 @@ public class LogManagerImpl implements LogManager {
                         reportError(RaftError.EBUSY.getNumber(), "LogManager is busy, disk queue overload.");
                         return;
                     }
-                    //TODO use Thread.onSpinWait instead in JDK9
-                    Thread.yield();
+                    ThreadHelper.onSpinWait();
                 }
             }
             doUnlock = false;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -50,6 +51,7 @@ import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogManager;
 import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.util.ArrayDeque;
+import com.alipay.sofa.jraft.util.DisruptorBuilder;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.Requires;
@@ -57,7 +59,9 @@ import com.alipay.sofa.jraft.util.Utils;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.RingBuffer;
+import com.lmax.disruptor.TimeoutBlockingWaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
 
 /**
  * LogManager implementation.
@@ -67,32 +71,34 @@ import com.lmax.disruptor.dsl.Disruptor;
  * 2018-Apr-04 4:42:20 PM
  */
 public class LogManagerImpl implements LogManager {
-    private static final Logger                              LOG                   = LoggerFactory
-                                                                                       .getLogger(LogManagerImpl.class);
+    private static final int                                 APPEND_LOG_RETRY_TIMES = 50;
+
+    private static final Logger                              LOG                    = LoggerFactory
+                                                                                        .getLogger(LogManagerImpl.class);
 
     private LogStorage                                       logStorage;
     private ConfigurationManager                             configManager;
     private FSMCaller                                        fsmCaller;
-    private final ReadWriteLock                              lock                  = new ReentrantReadWriteLock();
-    private final Lock                                       writeLock             = this.lock.writeLock();
-    private final Lock                                       readLock              = this.lock.readLock();
+    private final ReadWriteLock                              lock                   = new ReentrantReadWriteLock();
+    private final Lock                                       writeLock              = this.lock.writeLock();
+    private final Lock                                       readLock               = this.lock.readLock();
     private volatile boolean                                 stopped;
     private volatile boolean                                 hasError;
     private long                                             nextWaitId;
-    private LogId                                            diskId                = new LogId(0, 0);
-    private LogId                                            appliedId             = new LogId(0, 0);
+    private LogId                                            diskId                 = new LogId(0, 0);
+    private LogId                                            appliedId              = new LogId(0, 0);
     // TODO  use a lock-free concurrent list instead?
-    private ArrayDeque<LogEntry>                             logsInMemory          = new ArrayDeque<>();
+    private ArrayDeque<LogEntry>                             logsInMemory           = new ArrayDeque<>();
     private volatile long                                    firstLogIndex;
     private volatile long                                    lastLogIndex;
-    private volatile LogId                                   lastSnapshotId        = new LogId(0, 0);
-    private final Map<Long, WaitMeta>                        waitMap               = new HashMap<>();
+    private volatile LogId                                   lastSnapshotId         = new LogId(0, 0);
+    private final Map<Long, WaitMeta>                        waitMap                = new HashMap<>();
     private Disruptor<StableClosureEvent>                    disruptor;
     private RingBuffer<StableClosureEvent>                   diskQueue;
     private RaftOptions                                      raftOptions;
     private volatile CountDownLatch                          shutDownLatch;
     private NodeMetrics                                      nodeMetrics;
-    private final CopyOnWriteArrayList<LastLogIndexListener> lastLogIndexListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<LastLogIndexListener> lastLogIndexListeners  = new CopyOnWriteArrayList<>();
 
     private enum EventType {
         OTHER, // other event type.
@@ -180,8 +186,17 @@ public class LogManagerImpl implements LogManager {
             this.lastLogIndex = this.logStorage.getLastLogIndex();
             this.diskId = new LogId(this.lastLogIndex, getTermFromLogStorage(this.lastLogIndex));
             this.fsmCaller = opts.getFsmCaller();
-            this.disruptor = new Disruptor<>(new StableClosureEventFactory(), opts.getDisruptorBufferSize(),
-                    new NamedThreadFactory("JRaft-LogManager-Disruptor-", true));
+            this.disruptor = DisruptorBuilder.<StableClosureEvent> newInstance() //
+                    .setEventFactory(new StableClosureEventFactory()) //
+                    .setRingBufferSize(opts.getDisruptorBufferSize()) //
+                    .setThreadFactory(new NamedThreadFactory("JRaft-LogManager-Disruptor-", true)) //
+                    .setProducerType(ProducerType.MULTI) //
+                    /**
+                     *  Use timeout strategy in log manager. If timeout happens, it will called reportError to halt the node.
+                     */
+                    .setWaitStrategy(new TimeoutBlockingWaitStrategy(
+                        this.raftOptions.getDisruptorPublishEventWaitTimeoutSecs(), TimeUnit.SECONDS)) //
+                    .build();
             this.disruptor.handleEventsWith(new StableClosureEventHandler());
             this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName(),
                     (event, ex) -> reportError(-1, "LogManager handle event error")));
@@ -310,7 +325,20 @@ public class LogManagerImpl implements LogManager {
                 this.logsInMemory.addAll(entries);
             }
             done.setEntries(entries);
-            offerEvent(done, EventType.OTHER);
+            int retryTimes = 0;
+            while (true) {
+                if (tryOfferEvent(done, EventType.OTHER)) {
+                    break;
+                } else {
+                    retryTimes++;
+                    if (retryTimes > APPEND_LOG_RETRY_TIMES) {
+                        reportError(RaftError.EBUSY.getNumber(), "LogManager is busy, disk queue overload.");
+                        return;
+                    }
+                    //TODO use Thread.onSpinWait instead in JDK9
+                    Thread.yield();
+                }
+            }
             doUnlock = false;
             if (!wakeupAllWaiter(this.writeLock)) {
                 notifyLastLogIndexListeners();
@@ -328,6 +356,18 @@ public class LogManagerImpl implements LogManager {
             return;
         }
         this.diskQueue.publishEvent((event, sequence) -> {
+            event.reset();
+            event.type = type;
+            event.done = done;
+        });
+    }
+
+    private boolean tryOfferEvent(final StableClosure done, final EventType type) {
+        if (this.stopped) {
+            Utils.runClosureInThread(done, new Status(RaftError.ESTOP, "Log manager is stopped."));
+            return true;
+        }
+        return this.diskQueue.tryPublishEvent((event, sequence) -> {
             event.reset();
             event.type = type;
             event.done = done;
@@ -529,6 +569,9 @@ public class LogManagerImpl implements LogManager {
     }
 
     private void setDiskId(final LogId id) {
+        if (id == null) {
+            return;
+        }
         LogId clearId;
         this.writeLock.lock();
         try {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorBuilder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import java.util.concurrent.ThreadFactory;
+
+import com.lmax.disruptor.BlockingWaitStrategy;
+import com.lmax.disruptor.EventFactory;
+import com.lmax.disruptor.WaitStrategy;
+import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
+
+/**
+ * A builder to build a disruptor instance.
+ * @author boyan(boyan@antfin.com)
+ *
+ */
+public class DisruptorBuilder<T> {
+    private EventFactory<T> eventFactory;
+    private Integer         ringBufferSize;
+    private ThreadFactory   threadFactory = new NamedThreadFactory("Disruptor-");
+    private ProducerType    producerType  = ProducerType.MULTI;
+    private WaitStrategy    waitStrategy  = new BlockingWaitStrategy();
+
+    private DisruptorBuilder() {
+    }
+
+    public static <T> DisruptorBuilder<T> newInstance() {
+        return new DisruptorBuilder<>();
+    }
+
+    public EventFactory<T> getEventFactory() {
+        return this.eventFactory;
+    }
+
+    public DisruptorBuilder<T> setEventFactory(final EventFactory<T> eventFactory) {
+        this.eventFactory = eventFactory;
+        return this;
+    }
+
+    public int getRingBufferSize() {
+        return this.ringBufferSize;
+    }
+
+    public DisruptorBuilder<T> setRingBufferSize(final int ringBufferSize) {
+        this.ringBufferSize = ringBufferSize;
+        return this;
+    }
+
+    public ThreadFactory getThreadFactory() {
+        return this.threadFactory;
+    }
+
+    public DisruptorBuilder<T> setThreadFactory(final ThreadFactory threadFactory) {
+        this.threadFactory = threadFactory;
+        return this;
+    }
+
+    public ProducerType getProducerType() {
+        return this.producerType;
+    }
+
+    public DisruptorBuilder<T> setProducerType(final ProducerType producerType) {
+        this.producerType = producerType;
+        return this;
+    }
+
+    public WaitStrategy getWaitStrategy() {
+        return this.waitStrategy;
+    }
+
+    public DisruptorBuilder<T> setWaitStrategy(final WaitStrategy waitStrategy) {
+        this.waitStrategy = waitStrategy;
+        return this;
+    }
+
+    public Disruptor<T> build() {
+        Requires.requireNonNull(this.ringBufferSize, " Ring buffer size not set");
+        Requires.requireNonNull(this.eventFactory, "Event factory not set");
+        return new Disruptor<>(this.eventFactory, this.ringBufferSize, this.threadFactory, this.producerType,
+            this.waitStrategy);
+    }
+
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadHelper.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadHelper.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ACC_VARARGS;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_1;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public final class ThreadHelper {
+
+    private static final Logger  LOG = LoggerFactory.getLogger(ThreadHelper.class);
+
+    private static final Spinner SPINNER;
+
+    static {
+        final Object maybeException = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+            try {
+                // noinspection JavaReflectionMemberAccess
+                Thread.class.getDeclaredMethod("onSpinWait");
+                return null;
+            } catch (final NoSuchMethodException | SecurityException e) {
+                return e;
+            }
+        });
+        if (maybeException == null) {
+            SPINNER = createSpinner();
+        } else {
+            SPINNER = new DefaultSpinner();
+        }
+    }
+
+    public static void onSpinWait() {
+        SPINNER.onSpinWait();
+    }
+
+    private ThreadHelper() {
+    }
+
+    public static abstract class Spinner {
+
+        public abstract void onSpinWait();
+    }
+
+    static class DefaultSpinner extends Spinner {
+
+        @Override
+        public void onSpinWait() {
+            Thread.yield();
+        }
+    }
+
+    private static Spinner createSpinner() {
+        final String superClassName = Spinner.class.getName();
+        final String superClassNameInternal = superClassName.replace('.', '/');
+
+        final String spinnerClassName = superClassName + "Impl";
+        final String spinnerClassNameInternal = spinnerClassName.replace('.', '/');
+
+        final String threadClassNameInternal = Thread.class.getName().replace('.', '/');
+
+        final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        cw.visit(V1_1, ACC_PUBLIC + ACC_SUPER, spinnerClassNameInternal, null, superClassNameInternal, null);
+
+        MethodVisitor mv;
+
+        // default constructor
+        {
+            mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, superClassNameInternal, "<init>", "()V", false);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(0, 0);
+            mv.visitEnd();
+        }
+
+        // implementation of method: `public abstract void onSpinWait()`
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_VARARGS, "onSpinWait", "()V", null, null);
+            mv.visitCode();
+            mv.visitMethodInsn(INVOKESTATIC, threadClassNameInternal, "onSpinWait", "()V", false);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(0, 0);
+            mv.visitEnd();
+        }
+
+        cw.visitEnd();
+
+        try {
+            final byte[] classBytes = cw.toByteArray();
+            final Class<?> spinnerClass = SpinnerClassLoader.INSTANCE.defineClass(spinnerClassName, classBytes);
+            return (Spinner) spinnerClass.getDeclaredConstructor().newInstance();
+        } catch (final Throwable t) {
+            LOG.warn("Error constructing spinner class: {}, will return a default spinner.", spinnerClassName, t);
+            return new DefaultSpinner();
+        }
+    }
+
+    private static class SpinnerClassLoader extends ClassLoader {
+
+        static final SpinnerClassLoader INSTANCE;
+
+        static {
+            ClassLoader parent = Spinner.class.getClassLoader();
+            if (parent == null) {
+                parent = ClassLoader.getSystemClassLoader();
+            }
+            INSTANCE = new SpinnerClassLoader(parent);
+        }
+
+        SpinnerClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        Class<?> defineClass(final String name, final byte[] bytes) throws ClassFormatError {
+            return defineClass(name, bytes, 0, bytes.length, getClass().getProtectionDomain());
+        }
+    }
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
@@ -16,6 +16,12 @@
  */
 package com.alipay.sofa.jraft.core;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
@@ -45,12 +51,6 @@ import com.alipay.sofa.jraft.test.TestUtils;
 import com.alipay.sofa.jraft.util.Bytes;
 import com.alipay.sofa.jraft.util.Utils;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 @RunWith(MockitoJUnitRunner.class)
 public class ReadOnlyServiceTest {
 
@@ -66,14 +66,13 @@ public class ReadOnlyServiceTest {
     public void setup() {
         this.readOnlyServiceImpl = new ReadOnlyServiceImpl();
         final ReadOnlyServiceOptions opts = new ReadOnlyServiceOptions();
-        opts.setFsmCaller(fsmCaller);
-        opts.setNode(node);
+        opts.setFsmCaller(this.fsmCaller);
+        opts.setNode(this.node);
         opts.setRaftOptions(new RaftOptions());
-        assertTrue(this.readOnlyServiceImpl.init(opts));
-
         Mockito.when(this.node.getNodeMetrics()).thenReturn(new NodeMetrics(false));
         Mockito.when(this.node.getGroupId()).thenReturn("test");
         Mockito.when(this.node.getServerId()).thenReturn(new PeerId("localhost:8081", 0));
+        assertTrue(this.readOnlyServiceImpl.init(opts));
     }
 
     @After
@@ -88,7 +87,7 @@ public class ReadOnlyServiceTest {
         this.readOnlyServiceImpl.addRequest(requestContext, new ReadIndexClosure() {
 
             @Override
-            public void run(Status status, long index, byte[] reqCtx) {
+            public void run(final Status status, final long index, final byte[] reqCtx) {
 
             }
         });
@@ -96,7 +95,7 @@ public class ReadOnlyServiceTest {
         Mockito.verify(this.node).handleReadIndexRequest(Mockito.argThat(new ArgumentMatcher<ReadIndexRequest>() {
 
             @Override
-            public boolean matches(Object argument) {
+            public boolean matches(final Object argument) {
                 if (argument instanceof ReadIndexRequest) {
                     final ReadIndexRequest req = (ReadIndexRequest) argument;
                     return req.getGroupId().equals("test") && req.getServerId().equals("localhost:8081:0")
@@ -116,7 +115,7 @@ public class ReadOnlyServiceTest {
         this.readOnlyServiceImpl.addRequest(requestContext, new ReadIndexClosure() {
 
             @Override
-            public void run(Status status, long index, byte[] reqCtx) {
+            public void run(final Status status, final long index, final byte[] reqCtx) {
                 assertTrue(status.isOk());
                 assertEquals(index, 1);
                 assertArrayEquals(reqCtx, requestContext);
@@ -130,7 +129,7 @@ public class ReadOnlyServiceTest {
         Mockito.verify(this.node).handleReadIndexRequest(Mockito.argThat(new ArgumentMatcher<ReadIndexRequest>() {
 
             @Override
-            public boolean matches(Object argument) {
+            public boolean matches(final Object argument) {
                 if (argument instanceof ReadIndexRequest) {
                     final ReadIndexRequest req = (ReadIndexRequest) argument;
                     return req.getGroupId().equals("test") && req.getServerId().equals("localhost:8081:0")
@@ -163,7 +162,7 @@ public class ReadOnlyServiceTest {
         this.readOnlyServiceImpl.addRequest(requestContext, new ReadIndexClosure() {
 
             @Override
-            public void run(Status status, long index, byte[] reqCtx) {
+            public void run(final Status status, final long index, final byte[] reqCtx) {
                 assertFalse(status.isOk());
                 assertEquals(index, -1);
                 assertArrayEquals(reqCtx, requestContext);
@@ -177,7 +176,7 @@ public class ReadOnlyServiceTest {
         Mockito.verify(this.node).handleReadIndexRequest(Mockito.argThat(new ArgumentMatcher<ReadIndexRequest>() {
 
             @Override
-            public boolean matches(Object argument) {
+            public boolean matches(final Object argument) {
                 if (argument instanceof ReadIndexRequest) {
                     final ReadIndexRequest req = (ReadIndexRequest) argument;
                     return req.getGroupId().equals("test") && req.getServerId().equals("localhost:8081:0")
@@ -208,7 +207,7 @@ public class ReadOnlyServiceTest {
         this.readOnlyServiceImpl.addRequest(requestContext, new ReadIndexClosure() {
 
             @Override
-            public void run(Status status, long index, byte[] reqCtx) {
+            public void run(final Status status, final long index, final byte[] reqCtx) {
                 assertTrue(status.isOk());
                 assertEquals(index, 1);
                 assertArrayEquals(reqCtx, requestContext);
@@ -222,7 +221,7 @@ public class ReadOnlyServiceTest {
         Mockito.verify(this.node).handleReadIndexRequest(Mockito.argThat(new ArgumentMatcher<ReadIndexRequest>() {
 
             @Override
-            public boolean matches(Object argument) {
+            public boolean matches(final Object argument) {
                 if (argument instanceof ReadIndexRequest) {
                     final ReadIndexRequest req = (ReadIndexRequest) argument;
                     return req.getGroupId().equals("test") && req.getServerId().equals("localhost:8081:0")
@@ -251,7 +250,7 @@ public class ReadOnlyServiceTest {
         final ReadIndexState state = new ReadIndexState(new Bytes(reqContext), new ReadIndexClosure() {
 
             @Override
-            public void run(Status status, long index, byte[] reqCtx) {
+            public void run(final Status status, final long index, final byte[] reqCtx) {
                 assertTrue(status.isOk());
                 assertEquals(index, 1);
                 assertArrayEquals(reqCtx, reqContext);

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <affinity.version>3.1.7</affinity.version>
+        <asm.version>6.0</asm.version>
         <bolt.version>1.5.3</bolt.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>
@@ -104,6 +105,12 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jraft-rheakv-pd</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <!-- asm -->
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
             </dependency>
             <!-- jsr305 -->
             <dependency>


### PR DESCRIPTION
### Motivation:

Fix #138 , refused new requests when the raft node is overload.

### Modification:

* Adds `DisruptorBuilder` to build disruptor, refactor code.
* Use `tryPublishEvent` to replace `publishEvent` in `NodeImpl#apply` and `ReadOnlyServiceImpl#addRequest` to defense overload requests.
* Use `TimeoutBlockingWaitStrategy` for `LogManagerImpl` disruptor, when `diskQueue` is overload, it will wait at most 10 seconds(setting by `RaftOptions#disruptorPublishEventWaitTimeoutSecs`)  to put new event. If timed out, the node will be halt.
* Some minor changes to avoid dead lock.
* Adds a test `NodeTest#testNodeTaskOverload`


