### PR TITLE
(fix) add destroyRocksDB()

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -1372,6 +1372,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
     // a backupable database.
     private static BackupableDBOptions createBackupDBOptions(final String backupDBPath) {
         return new BackupableDBOptions(backupDBPath) //
+            .setSync(true) //
             .setShareTableFiles(false); // don't share data between backups
     }
 }


### PR DESCRIPTION
### Motivation:

Use RocksDB.destroyDB() instead of deleting the DB directory manually.
The major difference is that DestroyDB() will take care of the case where the RocksDB database is stored in multiple directories. For instance, a single DB can be configured to store its data in multiple directories by specifying different paths to DBOptions::db_paths, DBOptions::db_log_dir, and DBOptions::wal_dir.

### Modification:

Add destroyRocksDB method

### Result:
